### PR TITLE
feat: 플랜 생성 기능 추가

### DIFF
--- a/src/main/kotlin/kr/wooco/woocobe/plan/domain/gateway/PlanStorageGateway.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/plan/domain/gateway/PlanStorageGateway.kt
@@ -1,0 +1,7 @@
+package kr.wooco.woocobe.plan.domain.gateway
+
+import kr.wooco.woocobe.plan.domain.model.Plan
+
+interface PlanStorageGateway {
+    fun save(plan: Plan): Plan
+}

--- a/src/main/kotlin/kr/wooco/woocobe/plan/domain/model/Plan.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/plan/domain/model/Plan.kt
@@ -1,0 +1,26 @@
+package kr.wooco.woocobe.plan.domain.model
+
+import java.time.LocalDate
+
+// TODO: 장소 정보 추가
+class Plan(
+    val id: Long,
+    val userId: Long,
+    val regionInfo: PlanRegionInfo,
+    val visitDate: LocalDate,
+) {
+    companion object {
+        fun register(
+            planId: Long,
+            userId: Long,
+            regionInfo: PlanRegionInfo,
+            visitDate: LocalDate,
+        ): Plan =
+            Plan(
+                id = planId,
+                userId = userId,
+                regionInfo = regionInfo,
+                visitDate = visitDate,
+            )
+    }
+}

--- a/src/main/kotlin/kr/wooco/woocobe/plan/domain/model/PlanRegionInfo.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/plan/domain/model/PlanRegionInfo.kt
@@ -1,0 +1,17 @@
+package kr.wooco.woocobe.plan.domain.model
+
+class PlanRegionInfo(
+    val majorRegion: String,
+    val subRegion: String,
+) {
+    companion object {
+        fun register(
+            majorRegion: String,
+            subRegion: String,
+        ): PlanRegionInfo =
+            PlanRegionInfo(
+                majorRegion = majorRegion,
+                subRegion = subRegion,
+            )
+    }
+}

--- a/src/main/kotlin/kr/wooco/woocobe/plan/infrastructure/gateway/JpaPlanStorageGateway.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/plan/infrastructure/gateway/JpaPlanStorageGateway.kt
@@ -1,0 +1,14 @@
+package kr.wooco.woocobe.plan.infrastructure.gateway
+
+import kr.wooco.woocobe.plan.domain.gateway.PlanStorageGateway
+import kr.wooco.woocobe.plan.domain.model.Plan
+import kr.wooco.woocobe.plan.infrastructure.storage.PlanEntity
+import kr.wooco.woocobe.plan.infrastructure.storage.PlanJpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+class JpaPlanStorageGateway(
+    private val planJpaRepository: PlanJpaRepository,
+) : PlanStorageGateway {
+    override fun save(plan: Plan): Plan = planJpaRepository.save(PlanEntity.from(plan)).toDomain()
+}

--- a/src/main/kotlin/kr/wooco/woocobe/plan/infrastructure/storage/PlanEntity.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/plan/infrastructure/storage/PlanEntity.kt
@@ -1,0 +1,47 @@
+package kr.wooco.woocobe.plan.infrastructure.storage
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import kr.wooco.woocobe.common.storage.BaseTimeEntity
+import kr.wooco.woocobe.plan.domain.model.Plan
+import kr.wooco.woocobe.plan.domain.model.PlanRegionInfo
+import java.time.LocalDate
+
+@Entity
+@Table(name = "plans")
+class PlanEntity(
+    @Column(name = "user_id")
+    val userId: Long,
+    @Column(name = "major_region")
+    val majorRegion: String,
+    @Column(name = "sub_region")
+    val subRegion: String,
+    @Column(name = "visit_date")
+    val visitDate: LocalDate,
+    @Id
+    @Column(name = "plan_id")
+    val id: Long,
+) : BaseTimeEntity() {
+    fun toDomain(): Plan =
+        Plan(
+            id = id,
+            userId = userId,
+            regionInfo = PlanRegionInfo.register(majorRegion, subRegion),
+            visitDate = visitDate,
+        )
+
+    companion object {
+        fun from(plan: Plan): PlanEntity =
+            with(plan) {
+                PlanEntity(
+                    id = id,
+                    userId = userId,
+                    majorRegion = regionInfo.majorRegion,
+                    subRegion = regionInfo.subRegion,
+                    visitDate = visitDate,
+                )
+            }
+    }
+}

--- a/src/main/kotlin/kr/wooco/woocobe/plan/infrastructure/storage/PlanJpaRepository.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/plan/infrastructure/storage/PlanJpaRepository.kt
@@ -1,0 +1,5 @@
+package kr.wooco.woocobe.plan.infrastructure.storage
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface PlanJpaRepository : JpaRepository<PlanEntity, Long>


### PR DESCRIPTION
## 📝 개요

플랜 도메인에서 기본적으로 필요한 플랜 생성 로직 추가

## ✨ 변경 사항

✨ 기본적인 플랜 도메인 로직 추가
✨ 플랜 JPA 엔티티 및 JPA 리포지토리 추가

## 🔗 관련 이슈

- closed #15 

## ℹ️ 참고 사항

- 유저(User) 도메인 코드와 최대한 컨벤션을 맞추고자 했습니다.
- 추후 장소(Place) 도메인이 추가시 플랜(Plan)에도 장소 정보를 추가해야합니다.
    - 장소 저장 로직이 필요합니다.
    - 장소 조회 로직이 필요합니다.
- `PlanRegionInfo` 의 경우 지역 정보를 추후 전역으로 관리한다면 변경될 수 있습니다.