### PR TITLE
feat: 쿠키 핸들링 확장 함수 추가 및 적용

### DIFF
--- a/src/main/kotlin/kr/wooco/woocobe/WoocoBeApplication.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/WoocoBeApplication.kt
@@ -1,9 +1,11 @@
 package kr.wooco.woocobe
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan
 import org.springframework.boot.runApplication
 
 @SpringBootApplication
+@ConfigurationPropertiesScan
 class WoocoBeApplication
 
 fun main(args: Array<String>) {

--- a/src/main/kotlin/kr/wooco/woocobe/common/utils/CookieExtensions.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/common/utils/CookieExtensions.kt
@@ -1,0 +1,44 @@
+package kr.wooco.woocobe.common.utils
+
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.http.HttpHeaders
+import org.springframework.http.ResponseCookie
+
+private val properties: CookieProperties by lazy {
+    SpringContextLoader.getBean(CookieProperties::class.java)
+}
+
+fun HttpServletResponse.addCookie(
+    name: String,
+    value: String = "",
+    maxAge: Long = properties.maxAge,
+) = this.setHeader(HttpHeaders.SET_COOKIE, makeCookie(name, value, maxAge))
+
+fun HttpServletResponse.deleteCookie(name: String) = this.setHeader(HttpHeaders.SET_COOKIE, makeCookie(name, "", 0))
+
+private fun makeCookie(
+    name: String,
+    value: String,
+    maxAge: Long,
+): String =
+    ResponseCookie
+        .from(name, value)
+        .maxAge(maxAge)
+        .path(properties.path)
+        .domain(properties.domain)
+        .sameSite(properties.sameSite)
+        .secure(properties.secure)
+        .httpOnly(properties.httpOnly)
+        .build()
+        .toString()
+
+@ConfigurationProperties(prefix = "spring.cookie")
+data class CookieProperties(
+    val path: String,
+    val maxAge: Long,
+    val sameSite: String,
+    val domain: String,
+    val secure: Boolean,
+    val httpOnly: Boolean,
+)

--- a/src/main/kotlin/kr/wooco/woocobe/common/utils/SpringContextLoader.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/common/utils/SpringContextLoader.kt
@@ -1,0 +1,16 @@
+package kr.wooco.woocobe.common.utils
+
+import org.springframework.context.ApplicationContext
+import org.springframework.context.ApplicationContextAware
+import org.springframework.stereotype.Component
+
+@Component
+object SpringContextLoader : ApplicationContextAware {
+    private lateinit var context: ApplicationContext
+
+    override fun setApplicationContext(applicationContext: ApplicationContext) {
+        context = applicationContext
+    }
+
+    fun <T> getBean(beanClass: Class<T>): T = context.getBean(beanClass)
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -3,6 +3,14 @@ server:
   shutdown: graceful
 
 spring:
+  cookie:
+    path: /
+    max-age: 9876543210
+    same-site: Lax
+    domain: localhost
+    secure: false
+    http-only: true
+
   jpa:
     hibernate:
       ddl-auto: ${LOCAL_DDL_AUTO:update}


### PR DESCRIPTION
## 📝 개요

<!-- 이 PR의 목적과 관련된 정보를 간략히 설명합니다. -->

응답시 쿠키에 새로운 데이터를 추가하거나 삭제할 수 있는 확장 함수 추가

## ✨ 변경 사항

<!-- 코드나 기능의 주요 변경 사항을 설명 -->

- ✨ 쿠키 프로퍼티 설정 추가
- ✨ 쿠키 핸들링을 위한 확장 함수 추가
- ✨ `refresh_token` 발급시 쿠키에 저장되도록 수정

## 🔗 관련 이슈

<!-- 이 PR과 관련된 이슈 번호를 연결 (없으면 생략) -->

- closed #20 

## ℹ️ 참고 사항

<!-- 리뷰어가 알 필요가 있는 추가 정보나 문서, 참고 링크를 포함 (없으면 생략) -->

- 
