### PR TITLE
feat: 코스 도메인 기능 추가

### DIFF
--- a/src/main/kotlin/kr/wooco/woocobe/course/domain/gateway/CourseStorageGateway.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/course/domain/gateway/CourseStorageGateway.kt
@@ -1,9 +1,24 @@
 package kr.wooco.woocobe.course.domain.gateway
 
 import kr.wooco.woocobe.course.domain.model.Course
+import kr.wooco.woocobe.course.domain.model.CourseRegion
+import kr.wooco.woocobe.course.domain.model.CourseSortCondition
 
 interface CourseStorageGateway {
     fun save(course: Course): Course
 
     fun getByCourseId(courseId: Long): Course?
+
+    fun getAllByRegionAndCategoryWithSort(
+        region: CourseRegion,
+        category: String,
+        sort: CourseSortCondition,
+    ): List<Course>
+
+    fun getAllByUserIdWithSort(
+        userId: Long,
+        sort: CourseSortCondition,
+    ): List<Course>
+
+    fun deleteByCourseId(courseId: Long)
 }

--- a/src/main/kotlin/kr/wooco/woocobe/course/domain/gateway/CourseStorageGateway.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/course/domain/gateway/CourseStorageGateway.kt
@@ -1,0 +1,9 @@
+package kr.wooco.woocobe.course.domain.gateway
+
+import kr.wooco.woocobe.course.domain.model.Course
+
+interface CourseStorageGateway {
+    fun save(course: Course): Course
+
+    fun getByCourseId(courseId: Long): Course?
+}

--- a/src/main/kotlin/kr/wooco/woocobe/course/domain/model/Course.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/course/domain/model/Course.kt
@@ -1,0 +1,80 @@
+package kr.wooco.woocobe.course.domain.model
+
+import kr.wooco.woocobe.user.domain.model.User
+import java.time.LocalDateTime
+
+class Course(
+    val id: Long,
+    val user: User,
+    val region: CourseRegion,
+    val writeDateTime: LocalDateTime,
+    var categories: List<CourseCategory>,
+    var name: String,
+    var contents: String,
+    var views: Long,
+    var comments: Long,
+    var interests: Long,
+) {
+    fun increaseViews() =
+        apply {
+            views++
+        }
+
+    fun increaseComments() =
+        apply {
+            comments++
+        }
+
+    fun decreaseComments() =
+        apply {
+            comments--
+        }
+
+    fun increaseInterests() =
+        apply {
+            interests++
+        }
+
+    fun decreaseInterests() =
+        apply {
+            interests--
+        }
+
+    fun update(
+        name: String,
+        categories: List<String>,
+        contents: String,
+    ) = apply {
+        this.name = name
+        this.categories = categories.map { CourseCategory.from(it) }
+        this.contents = contents
+    }
+
+    fun isWriter(targetId: Long): Boolean =
+        when (user.id == targetId) {
+            true -> true
+            else -> throw RuntimeException()
+        }
+
+    companion object {
+        fun register(
+            user: User,
+            region: CourseRegion,
+            categories: List<String>,
+            name: String,
+            contents: String,
+        ): Course =
+            Course(
+                id = 0L,
+                user = user,
+                region = region,
+                categories = categories.map { CourseCategory.from(it) },
+                writeDateTime = LocalDateTime.now(),
+                name = name,
+                contents = contents,
+                views = 0L,
+                comments = 0L,
+                interests = 0L,
+            )
+    }
+}

--- a/src/main/kotlin/kr/wooco/woocobe/course/domain/model/CourseCategory.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/course/domain/model/CourseCategory.kt
@@ -1,0 +1,16 @@
+package kr.wooco.woocobe.course.domain.model
+
+enum class CourseCategory {
+    FAMOUS_RESTAURANT,
+    ACTIVITY,
+    HOT_PLACE,
+    CULTURE_AND_ART,
+    ETC,
+    ;
+
+    companion object {
+        fun from(viewName: String) =
+            entries.find { it.name == viewName }
+                ?: throw RuntimeException("not found course category $viewName")
+    }
+}

--- a/src/main/kotlin/kr/wooco/woocobe/course/domain/model/CourseRegion.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/course/domain/model/CourseRegion.kt
@@ -1,0 +1,17 @@
+package kr.wooco.woocobe.course.domain.model
+
+class CourseRegion(
+    val primaryRegion: String,
+    val secondaryRegion: String,
+) {
+    companion object {
+        fun register(
+            primaryRegion: String,
+            secondaryRegion: String,
+        ): CourseRegion =
+            CourseRegion(
+                primaryRegion = primaryRegion,
+                secondaryRegion = secondaryRegion,
+            )
+    }
+}

--- a/src/main/kotlin/kr/wooco/woocobe/course/domain/model/CourseSortCondition.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/course/domain/model/CourseSortCondition.kt
@@ -1,0 +1,13 @@
+package kr.wooco.woocobe.course.domain.model
+
+enum class CourseSortCondition {
+    POPULAR,
+    RECENT,
+    ;
+
+    companion object {
+        fun from(value: String): CourseSortCondition =
+            entries.find { it.name == value }
+                ?: throw RuntimeException()
+    }
+}

--- a/src/main/kotlin/kr/wooco/woocobe/course/domain/usecase/AddCourseUseCase.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/course/domain/usecase/AddCourseUseCase.kt
@@ -1,0 +1,42 @@
+package kr.wooco.woocobe.course.domain.usecase
+
+import kr.wooco.woocobe.common.domain.UseCase
+import kr.wooco.woocobe.course.domain.gateway.CourseStorageGateway
+import kr.wooco.woocobe.course.domain.model.Course
+import kr.wooco.woocobe.course.domain.model.CourseRegion
+import kr.wooco.woocobe.user.domain.model.User
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+data class AddCourseUseCaseInput(
+    val userId: Long,
+    val primaryRegion: String,
+    val secondaryRegion: String,
+    val category: List<String>,
+    val name: String,
+    val contents: String,
+)
+
+@Service
+class AddCourseUseCase(
+    private val courseStorageGateway: CourseStorageGateway,
+) : UseCase<AddCourseUseCaseInput, Unit> {
+    @Transactional
+    override fun execute(input: AddCourseUseCaseInput) {
+        val user = User.register(userId = input.userId)
+
+        val courseRegion = CourseRegion.register(
+            primaryRegion = input.primaryRegion,
+            secondaryRegion = input.secondaryRegion,
+        )
+
+        Course
+            .register(
+                user = user,
+                region = courseRegion,
+                categories = input.category,
+                name = input.name,
+                contents = input.contents,
+            ).also(courseStorageGateway::save)
+    }
+}

--- a/src/main/kotlin/kr/wooco/woocobe/course/domain/usecase/DeleteCourseUseCase.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/course/domain/usecase/DeleteCourseUseCase.kt
@@ -1,0 +1,29 @@
+package kr.wooco.woocobe.course.domain.usecase
+
+import kr.wooco.woocobe.common.domain.UseCase
+import kr.wooco.woocobe.course.domain.gateway.CourseStorageGateway
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+data class DeleteCourseInput(
+    val userId: Long,
+    val courseId: Long,
+)
+
+@Service
+class DeleteCourseUseCase(
+    private val courseStorageGateway: CourseStorageGateway,
+) : UseCase<DeleteCourseInput, Unit> {
+    @Transactional
+    override fun execute(input: DeleteCourseInput) {
+        val course = courseStorageGateway
+            .getByCourseId(courseId = input.courseId)
+            ?: throw RuntimeException()
+
+        when {
+            course.isWriter(input.userId).not() -> throw RuntimeException()
+        }
+
+        courseStorageGateway.deleteByCourseId(courseId = course.id)
+    }
+}

--- a/src/main/kotlin/kr/wooco/woocobe/course/domain/usecase/GetAllCourseUseCase.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/course/domain/usecase/GetAllCourseUseCase.kt
@@ -1,0 +1,39 @@
+package kr.wooco.woocobe.course.domain.usecase
+
+import kr.wooco.woocobe.common.domain.UseCase
+import kr.wooco.woocobe.course.domain.gateway.CourseStorageGateway
+import kr.wooco.woocobe.course.domain.model.Course
+import kr.wooco.woocobe.course.domain.model.CourseRegion
+import kr.wooco.woocobe.course.domain.model.CourseSortCondition
+import org.springframework.stereotype.Service
+
+data class GetAllCourseInput(
+    val primaryRegion: String,
+    val secondaryRegion: String,
+    val category: String,
+    val sort: String,
+)
+
+data class GetAllCourseOutput(
+    val courses: List<Course>,
+)
+
+@Service
+class GetAllCourseUseCase(
+    private val courseStorageGateway: CourseStorageGateway,
+) : UseCase<GetAllCourseInput, GetAllCourseOutput> {
+    override fun execute(input: GetAllCourseInput): GetAllCourseOutput {
+        val sort = CourseSortCondition.from(value = input.sort)
+        val region = CourseRegion.register(primaryRegion = input.primaryRegion, secondaryRegion = input.secondaryRegion)
+
+        val courses = courseStorageGateway.getAllByRegionAndCategoryWithSort(
+            region = region,
+            category = input.category,
+            sort = sort,
+        )
+
+        return GetAllCourseOutput(
+            courses = courses,
+        )
+    }
+}

--- a/src/main/kotlin/kr/wooco/woocobe/course/domain/usecase/GetCourseUseCase.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/course/domain/usecase/GetCourseUseCase.kt
@@ -1,0 +1,31 @@
+package kr.wooco.woocobe.course.domain.usecase
+
+import kr.wooco.woocobe.common.domain.UseCase
+import kr.wooco.woocobe.course.domain.gateway.CourseStorageGateway
+import kr.wooco.woocobe.course.domain.model.Course
+import org.springframework.stereotype.Service
+
+data class GetCourseInput(
+    val userId: Long?,
+    val courseId: Long,
+)
+
+data class GetCourseOutput(
+    val course: Course,
+)
+
+@Service
+class GetCourseUseCase(
+    private val courseStorageGateway: CourseStorageGateway,
+) : UseCase<GetCourseInput, GetCourseOutput> {
+    override fun execute(input: GetCourseInput): GetCourseOutput {
+        val course = courseStorageGateway.getByCourseId(input.courseId)
+            ?: throw RuntimeException()
+
+        course.increaseViews().also(courseStorageGateway::save)
+
+        return GetCourseOutput(
+            course = course,
+        )
+    }
+}

--- a/src/main/kotlin/kr/wooco/woocobe/course/domain/usecase/GetUserAllCourseUseCase.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/course/domain/usecase/GetUserAllCourseUseCase.kt
@@ -1,0 +1,29 @@
+package kr.wooco.woocobe.course.domain.usecase
+
+import kr.wooco.woocobe.common.domain.UseCase
+import kr.wooco.woocobe.course.domain.gateway.CourseStorageGateway
+import kr.wooco.woocobe.course.domain.model.Course
+import kr.wooco.woocobe.course.domain.model.CourseSortCondition
+import org.springframework.stereotype.Service
+
+data class GetUserAllCourseInput(
+    val userId: Long,
+    val sort: CourseSortCondition,
+)
+
+data class GetUserAllCourseOutput(
+    val courses: List<Course>,
+)
+
+@Service
+class GetUserAllCourseUseCase(
+    private val courseStorageGateway: CourseStorageGateway,
+) : UseCase<GetUserAllCourseInput, GetUserAllCourseOutput> {
+    override fun execute(input: GetUserAllCourseInput): GetUserAllCourseOutput {
+        val courses = courseStorageGateway.getAllByUserIdWithSort(input.userId, input.sort)
+
+        return GetUserAllCourseOutput(
+            courses = courses,
+        )
+    }
+}

--- a/src/main/kotlin/kr/wooco/woocobe/course/domain/usecase/UpdateCourseUseCase.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/course/domain/usecase/UpdateCourseUseCase.kt
@@ -1,0 +1,36 @@
+package kr.wooco.woocobe.course.domain.usecase
+
+import kr.wooco.woocobe.common.domain.UseCase
+import kr.wooco.woocobe.course.domain.gateway.CourseStorageGateway
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+data class UpdateCourseInput(
+    val userId: Long,
+    val courseId: Long,
+    val name: String,
+    val contents: String,
+    val categories: List<String>,
+)
+
+@Service
+class UpdateCourseUseCase(
+    private val courseStorageGateway: CourseStorageGateway,
+) : UseCase<UpdateCourseInput, Unit> {
+    @Transactional
+    override fun execute(input: UpdateCourseInput) {
+        val course = courseStorageGateway.getByCourseId(courseId = input.courseId)
+            ?: throw RuntimeException()
+
+        when {
+            course.isWriter(input.userId).not() -> throw RuntimeException()
+        }
+
+        course
+            .update(
+                name = input.name,
+                contents = input.contents,
+                categories = input.categories,
+            ).also(courseStorageGateway::save)
+    }
+}

--- a/src/main/kotlin/kr/wooco/woocobe/course/infrastructure/gateway/JpaCourseStorageGateway.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/course/infrastructure/gateway/JpaCourseStorageGateway.kt
@@ -1,0 +1,83 @@
+package kr.wooco.woocobe.course.infrastructure.gateway
+
+import kr.wooco.woocobe.course.domain.gateway.CourseStorageGateway
+import kr.wooco.woocobe.course.domain.model.Course
+import kr.wooco.woocobe.course.domain.model.CourseRegion
+import kr.wooco.woocobe.course.domain.model.CourseSortCondition
+import kr.wooco.woocobe.course.infrastructure.storage.CourseCategoryEntity
+import kr.wooco.woocobe.course.infrastructure.storage.CourseCategoryJpaRepository
+import kr.wooco.woocobe.course.infrastructure.storage.CourseEntity
+import kr.wooco.woocobe.course.infrastructure.storage.CourseJpaRepository
+import kr.wooco.woocobe.user.infrastructure.storage.UserJpaRepository
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Component
+
+@Component
+@Suppress("Duplicates") // TODO: 매퍼 클래스로 중복 제거
+class JpaCourseStorageGateway(
+    private val userJpaRepository: UserJpaRepository,
+    private val courseJpaRepository: CourseJpaRepository,
+    private val courseCategoryJpaRepository: CourseCategoryJpaRepository,
+) : CourseStorageGateway {
+    // FIXME: 업데이트 로직 분리
+    override fun save(course: Course): Course {
+        val courseEntity = courseJpaRepository.save(CourseEntity.from(course))
+        if (course.id == 0L) {
+            course.categories
+                .map { CourseCategoryEntity.of(courseId = courseEntity.id!!, name = it.name) }
+                .also(courseCategoryJpaRepository::saveAll)
+        }
+        return course
+    }
+
+    override fun getByCourseId(courseId: Long): Course? =
+        courseJpaRepository.findByIdOrNull(courseId)?.let { courseEntity ->
+            courseEntity.toDomain(
+                user = userJpaRepository.findByIdOrNull(courseEntity.userId)!!.toDomain(),
+                courseCategory = courseCategoryJpaRepository
+                    .findAllByCourseId(courseEntity.id!!)
+                    .map { it.toDomain() },
+            )
+        }
+
+    override fun getAllByRegionAndCategoryWithSort(
+        region: CourseRegion,
+        category: String,
+        sort: CourseSortCondition,
+    ): List<Course> =
+        courseJpaRepository
+            .findAllByRegionAndCategoryWithSort(region = region, category = category, sort = sort)
+            .run {
+                val userEntities = userJpaRepository.findAllById(map { it.userId })
+                val categoryEntities = courseCategoryJpaRepository.findAllByCourseIdIn(map { it.id!! })
+                map { courseEntity ->
+                    courseEntity.toDomain(
+                        user = userEntities.find { courseEntity.userId == it.id }!!.toDomain(),
+                        courseCategory = categoryEntities
+                            .filter { courseEntity.userId == it.courseId }
+                            .map { it.toDomain() },
+                    )
+                }
+            }
+
+    override fun getAllByUserIdWithSort(
+        userId: Long,
+        sort: CourseSortCondition,
+    ): List<Course> =
+        courseJpaRepository
+            .findAllByUserIdWithSort(userId = userId, sort = sort)
+            .run {
+                val userEntities = userJpaRepository.findAllById(map { it.userId })
+                val categoryEntities = courseCategoryJpaRepository.findAllByCourseIdIn(map { it.id!! })
+                map { courseEntity ->
+                    courseEntity.toDomain(
+                        user = userEntities.find { courseEntity.userId == it.id }!!.toDomain(),
+                        courseCategory = categoryEntities
+                            .filter { courseEntity.userId == it.courseId }
+                            .map { it.toDomain() },
+                    )
+                }
+            }
+
+    override fun deleteByCourseId(courseId: Long) = courseJpaRepository.deleteById(courseId)
+}

--- a/src/main/kotlin/kr/wooco/woocobe/course/infrastructure/storage/CourseCategoryEntity.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/course/infrastructure/storage/CourseCategoryEntity.kt
@@ -1,0 +1,34 @@
+package kr.wooco.woocobe.course.infrastructure.storage
+
+import io.hypersistence.utils.hibernate.id.Tsid
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import kr.wooco.woocobe.common.storage.BaseTimeEntity
+import kr.wooco.woocobe.course.domain.model.CourseCategory
+
+@Entity
+@Table(name = "course_categories")
+class CourseCategoryEntity(
+    @Column(name = "category_name")
+    val name: String,
+    @Column(name = "course_id")
+    val courseId: Long,
+    @Id @Tsid
+    @Column(name = "course_category_id")
+    val id: Long? = 0L,
+) : BaseTimeEntity() {
+    fun toDomain(): CourseCategory = CourseCategory.entries.find { it.name == name }!!
+
+    companion object {
+        fun of(
+            courseId: Long,
+            name: String,
+        ): CourseCategoryEntity =
+            CourseCategoryEntity(
+                courseId = courseId,
+                name = name,
+            )
+    }
+}

--- a/src/main/kotlin/kr/wooco/woocobe/course/infrastructure/storage/CourseCategoryJpaRepository.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/course/infrastructure/storage/CourseCategoryJpaRepository.kt
@@ -1,0 +1,9 @@
+package kr.wooco.woocobe.course.infrastructure.storage
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface CourseCategoryJpaRepository : JpaRepository<CourseCategoryEntity, Long> {
+    fun findAllByCourseId(courseId: Long): List<CourseCategoryEntity>
+
+    fun findAllByCourseIdIn(courseIds: List<Long>): List<CourseCategoryEntity>
+}

--- a/src/main/kotlin/kr/wooco/woocobe/course/infrastructure/storage/CourseCustomRepository.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/course/infrastructure/storage/CourseCustomRepository.kt
@@ -1,0 +1,17 @@
+package kr.wooco.woocobe.course.infrastructure.storage
+
+import kr.wooco.woocobe.course.domain.model.CourseRegion
+import kr.wooco.woocobe.course.domain.model.CourseSortCondition
+
+interface CourseCustomRepository {
+    fun findAllByUserIdWithSort(
+        userId: Long,
+        sort: CourseSortCondition,
+    ): List<CourseEntity>
+
+    fun findAllByRegionAndCategoryWithSort(
+        region: CourseRegion,
+        category: String,
+        sort: CourseSortCondition,
+    ): List<CourseEntity>
+}

--- a/src/main/kotlin/kr/wooco/woocobe/course/infrastructure/storage/CourseCustomRepositoryImpl.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/course/infrastructure/storage/CourseCustomRepositoryImpl.kt
@@ -1,0 +1,60 @@
+package kr.wooco.woocobe.course.infrastructure.storage
+
+import com.querydsl.jpa.impl.JPAQueryFactory
+import kr.wooco.woocobe.course.domain.model.CourseRegion
+import kr.wooco.woocobe.course.domain.model.CourseSortCondition
+import kr.wooco.woocobe.user.infrastructure.storage.QUserEntity
+import org.springframework.stereotype.Repository
+
+@Repository
+class CourseCustomRepositoryImpl(
+    private val queryFactory: JPAQueryFactory,
+) : CourseCustomRepository {
+    override fun findAllByUserIdWithSort(
+        userId: Long,
+        sort: CourseSortCondition,
+    ): List<CourseEntity> =
+        queryFactory
+            .selectFrom(course)
+            .leftJoin(courseCategory)
+            .on(course.id.eq(courseCategory.courseId))
+            .leftJoin(user)
+            .on(course.userId.eq(user.id))
+            .fetchJoin()
+            .where(course.id.eq(userId))
+            .orderBy(
+                when (sort) {
+                    CourseSortCondition.POPULAR -> course.viewCount.desc()
+                    CourseSortCondition.RECENT -> course.createdAt.desc()
+                },
+            ).fetch()
+
+    override fun findAllByRegionAndCategoryWithSort(
+        region: CourseRegion,
+        category: String,
+        sort: CourseSortCondition,
+    ): List<CourseEntity> =
+        queryFactory
+            .selectFrom(course)
+            .leftJoin(courseCategory)
+            .on(course.id.eq(courseCategory.courseId))
+            .leftJoin(user)
+            .on(course.userId.eq(user.id))
+            .fetchJoin()
+            .where(
+                course.primaryRegion.eq(region.primaryRegion),
+                course.secondaryRegion.eq(region.secondaryRegion),
+                courseCategory.name.eq(category),
+            ).orderBy(
+                when (sort) {
+                    CourseSortCondition.POPULAR -> course.viewCount.desc()
+                    CourseSortCondition.RECENT -> course.createdAt.desc()
+                },
+            ).fetch()
+
+    companion object {
+        private val user = QUserEntity.userEntity
+        private val course = QCourseEntity.courseEntity
+        private val courseCategory = QCourseCategoryEntity.courseCategoryEntity
+    }
+}

--- a/src/main/kotlin/kr/wooco/woocobe/course/infrastructure/storage/CourseEntity.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/course/infrastructure/storage/CourseEntity.kt
@@ -1,0 +1,73 @@
+package kr.wooco.woocobe.course.infrastructure.storage
+
+import io.hypersistence.utils.hibernate.id.Tsid
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import kr.wooco.woocobe.common.storage.BaseTimeEntity
+import kr.wooco.woocobe.course.domain.model.Course
+import kr.wooco.woocobe.course.domain.model.CourseCategory
+import kr.wooco.woocobe.course.domain.model.CourseRegion
+import kr.wooco.woocobe.user.domain.model.User
+
+@Entity
+@Table(name = "courses")
+class CourseEntity(
+    @Column(name = "comment_count")
+    val commentCount: Long,
+    @Column(name = "interest_count")
+    val interestCount: Long,
+    @Column(name = "view_count")
+    val viewCount: Long,
+    @Column(columnDefinition = "text")
+    val contents: String,
+    @Column(name = "secondary_region", nullable = false)
+    val secondaryRegion: String,
+    @Column(name = "primary_region", nullable = false)
+    val primaryRegion: String,
+    @Column(name = "name", nullable = false)
+    val name: String,
+    @Column(name = "user_id")
+    val userId: Long,
+    @Id @Tsid
+    @Column(name = "course_id", nullable = false)
+    val id: Long? = 0L,
+) : BaseTimeEntity() {
+    fun toDomain(
+        user: User,
+        courseCategory: List<CourseCategory> = emptyList(),
+    ): Course =
+        Course(
+            id = id!!,
+            user = user,
+            region = CourseRegion(
+                primaryRegion = primaryRegion,
+                secondaryRegion = secondaryRegion,
+            ),
+            writeDateTime = createdAt,
+            categories = courseCategory.map { CourseCategory.from(it.name) },
+            name = name,
+            contents = contents,
+            views = viewCount,
+            comments = commentCount,
+            interests = interestCount,
+        )
+
+    companion object {
+        fun from(course: Course): CourseEntity =
+            with(course) {
+                CourseEntity(
+                    id = id,
+                    userId = user.id,
+                    name = name,
+                    primaryRegion = region.primaryRegion,
+                    secondaryRegion = region.secondaryRegion,
+                    contents = contents,
+                    viewCount = views,
+                    commentCount = comments,
+                    interestCount = interests,
+                )
+            }
+    }
+}

--- a/src/main/kotlin/kr/wooco/woocobe/course/infrastructure/storage/CourseJpaRepository.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/course/infrastructure/storage/CourseJpaRepository.kt
@@ -1,0 +1,6 @@
+package kr.wooco.woocobe.course.infrastructure.storage
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+@Suppress("ktlint")
+interface CourseJpaRepository : JpaRepository<CourseEntity, Long>, CourseCustomRepository


### PR DESCRIPTION
## 📝 개요

<!-- 이 PR의 목적과 관련된 정보를 간략히 설명합니다. -->

코스 기본 도메인 기능 추가

## ✨ 변경 사항

<!-- 코드나 기능의 주요 변경 사항을 설명 -->

- ✨ 코스 기본 도메인 로직 추가
- ✨ 코스 엔티티 및 리포지토리 추가

## 🔗 관련 이슈

<!-- 이 PR과 관련된 이슈 번호를 연결 (없으면 생략) -->

- closed #22 

## ℹ️ 참고 사항

<!-- 리뷰어가 알 필요가 있는 추가 정보나 문서, 참고 링크를 포함 (없으면 생략) -->

코스 게이트웨이 구현체 부분의 `save()` 메서드에서 update와 save를 나누지 않아, 임시로 도메인 모델의 `id`값이 0인지 확인하는 분기처리 넣어놨습니다. 이 부분은 추후 리팩토링을 통해서 분리할 예정입니다!

관심 코스 및 코스 댓글 기능 추가 예정입니다!