### PR TITLE
feat: 회원 기능 추가

### DIFF
--- a/src/main/kotlin/kr/wooco/woocobe/user/domain/gateway/UserStorageGateway.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/user/domain/gateway/UserStorageGateway.kt
@@ -4,4 +4,6 @@ import kr.wooco.woocobe.user.domain.model.User
 
 interface UserStorageGateway {
     fun save(user: User): User
+
+    fun getByUserId(userId: Long): User?
 }

--- a/src/main/kotlin/kr/wooco/woocobe/user/domain/gateway/UserStorageGateway.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/user/domain/gateway/UserStorageGateway.kt
@@ -5,5 +5,9 @@ import kr.wooco.woocobe.user.domain.model.User
 interface UserStorageGateway {
     fun save(user: User): User
 
+    fun update(user: User): User
+
     fun getByUserId(userId: Long): User?
+
+    fun deleteByUserId(userId: Long)
 }

--- a/src/main/kotlin/kr/wooco/woocobe/user/domain/model/User.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/user/domain/model/User.kt
@@ -1,14 +1,28 @@
 package kr.wooco.woocobe.user.domain.model
 
-// TODO: 랜덤 닉네임 생성 로직이 필요
 class User(
     val id: Long,
-    var name: String = "",
+    var name: String,
+    var profileUrl: String,
 ) {
+    fun update(
+        name: String,
+        profileUrl: String,
+    ) = apply {
+        this.name = name
+        this.profileUrl = profileUrl
+    }
+
     companion object {
-        fun register(userId: Long): User =
+        fun register(
+            userId: Long = 0L,
+            name: String = "",
+            profileUrl: String = "",
+        ): User =
             User(
                 id = userId,
+                name = name,
+                profileUrl = profileUrl,
             )
     }
 }

--- a/src/main/kotlin/kr/wooco/woocobe/user/domain/usecase/GetUserUseCase.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/user/domain/usecase/GetUserUseCase.kt
@@ -1,0 +1,28 @@
+package kr.wooco.woocobe.user.domain.usecase
+
+import kr.wooco.woocobe.common.domain.UseCase
+import kr.wooco.woocobe.user.domain.gateway.UserStorageGateway
+import kr.wooco.woocobe.user.domain.model.User
+import org.springframework.stereotype.Service
+
+data class GetUserInput(
+    val userId: Long,
+)
+
+data class GetUserOutput(
+    val user: User,
+)
+
+@Service
+class GetUserUseCase(
+    private val userStorageGateway: UserStorageGateway,
+) : UseCase<GetUserInput, GetUserOutput> {
+    override fun execute(input: GetUserInput): GetUserOutput {
+        val user = userStorageGateway.getByUserId(userId = input.userId)
+            ?: throw RuntimeException()
+
+        return GetUserOutput(
+            user = user,
+        )
+    }
+}

--- a/src/main/kotlin/kr/wooco/woocobe/user/domain/usecase/UpdateUserUseCase.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/user/domain/usecase/UpdateUserUseCase.kt
@@ -1,0 +1,27 @@
+package kr.wooco.woocobe.user.domain.usecase
+
+import kr.wooco.woocobe.common.domain.UseCase
+import kr.wooco.woocobe.user.domain.gateway.UserStorageGateway
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+data class UpdateUserInput(
+    val userId: Long,
+    val name: String,
+    val profileUrl: String,
+)
+
+@Service
+class UpdateUserUseCase(
+    private val userStorageGateway: UserStorageGateway,
+) : UseCase<UpdateUserInput, Unit> {
+    @Transactional
+    override fun execute(input: UpdateUserInput) {
+        val user = userStorageGateway.getByUserId(userId = input.userId)
+            ?: throw RuntimeException()
+
+        user
+            .update(name = input.name, profileUrl = input.profileUrl)
+            .run(userStorageGateway::update)
+    }
+}

--- a/src/main/kotlin/kr/wooco/woocobe/user/infrastructure/gateway/JpaUserStorageGateway.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/user/infrastructure/gateway/JpaUserStorageGateway.kt
@@ -4,11 +4,18 @@ import kr.wooco.woocobe.user.domain.gateway.UserStorageGateway
 import kr.wooco.woocobe.user.domain.model.User
 import kr.wooco.woocobe.user.infrastructure.storage.UserEntity
 import kr.wooco.woocobe.user.infrastructure.storage.UserJpaRepository
-import org.springframework.stereotype.Repository
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Component
 
-@Repository
-class JpaUserStorageGateway(
+@Component
+internal class JpaUserStorageGateway(
     private val userJpaRepository: UserJpaRepository,
 ) : UserStorageGateway {
     override fun save(user: User): User = userJpaRepository.save(UserEntity.from(user)).toDomain()
+
+    override fun update(user: User) = userJpaRepository.save(UserEntity.fromWithId(user)).toDomain()
+
+    override fun getByUserId(userId: Long): User? = userJpaRepository.findByIdOrNull(userId)?.toDomain()
+
+    override fun deleteByUserId(userId: Long) = userJpaRepository.deleteById(userId)
 }

--- a/src/main/kotlin/kr/wooco/woocobe/user/infrastructure/storage/UserEntity.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/user/infrastructure/storage/UserEntity.kt
@@ -4,12 +4,16 @@ import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.Id
 import jakarta.persistence.Table
+import kr.wooco.woocobe.common.domain.IdGenerator
 import kr.wooco.woocobe.common.storage.BaseTimeEntity
 import kr.wooco.woocobe.user.domain.model.User
 
 @Entity
 @Table(name = "users")
 class UserEntity(
+    @Column(name = "profile_url")
+    val profileUrl: String,
+    @Column(name = "name")
     val name: String,
     @Id
     @Column(name = "user_id")
@@ -19,14 +23,26 @@ class UserEntity(
         User(
             id = id,
             name = name,
+            profileUrl = profileUrl,
         )
 
+    // TODO: 리팩토링 (from 과 fromWithId)
     companion object {
         fun from(user: User): UserEntity =
             with(user) {
                 UserEntity(
+                    id = IdGenerator.generateId(),
+                    name = name,
+                    profileUrl = profileUrl,
+                )
+            }
+
+        fun fromWithId(user: User): UserEntity =
+            with(user) {
+                UserEntity(
                     id = id,
                     name = name,
+                    profileUrl = profileUrl,
                 )
             }
     }

--- a/src/main/kotlin/kr/wooco/woocobe/user/ui/web/UserController.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/user/ui/web/UserController.kt
@@ -1,0 +1,50 @@
+package kr.wooco.woocobe.user.ui.web
+
+import kr.wooco.woocobe.user.domain.usecase.GetUserInput
+import kr.wooco.woocobe.user.domain.usecase.GetUserUseCase
+import kr.wooco.woocobe.user.domain.usecase.UpdateUserInput
+import kr.wooco.woocobe.user.domain.usecase.UpdateUserUseCase
+import kr.wooco.woocobe.user.ui.web.dto.request.UpdateUserProfileRequest
+import kr.wooco.woocobe.user.ui.web.dto.response.GetCurrentUserResponse
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/users")
+class UserController(
+    private val getUserUseCase: GetUserUseCase,
+    private val updateUserUseCase: UpdateUserUseCase,
+) {
+    @GetMapping("/me")
+    fun getCurrentUser(
+        @AuthenticationPrincipal userId: Long,
+    ): ResponseEntity<GetCurrentUserResponse> {
+        val result = getUserUseCase.execute(
+            GetUserInput(
+                userId = userId,
+            ),
+        )
+        val response = GetCurrentUserResponse.from(result)
+        return ResponseEntity.ok(response)
+    }
+
+    @PatchMapping("/profile")
+    fun updateProfile(
+        @AuthenticationPrincipal userId: Long,
+        @RequestBody request: UpdateUserProfileRequest,
+    ): ResponseEntity<Unit> {
+        updateUserUseCase.execute(
+            UpdateUserInput(
+                userId = userId,
+                name = request.name,
+                profileUrl = request.profileUrl,
+            ),
+        )
+        return ResponseEntity.ok().build()
+    }
+}

--- a/src/main/kotlin/kr/wooco/woocobe/user/ui/web/dto/request/UpdateUserProfileRequest.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/user/ui/web/dto/request/UpdateUserProfileRequest.kt
@@ -1,0 +1,6 @@
+package kr.wooco.woocobe.user.ui.web.dto.request
+
+data class UpdateUserProfileRequest(
+    val name: String,
+    val profileUrl: String,
+)

--- a/src/main/kotlin/kr/wooco/woocobe/user/ui/web/dto/response/GetCurrentUserResponse.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/user/ui/web/dto/response/GetCurrentUserResponse.kt
@@ -1,0 +1,20 @@
+package kr.wooco.woocobe.user.ui.web.dto.response
+
+import kr.wooco.woocobe.user.domain.usecase.GetUserOutput
+
+data class GetCurrentUserResponse(
+    val userId: Long,
+    val name: String,
+    val profileUrl: String,
+) {
+    companion object {
+        fun from(getUserOutput: GetUserOutput): GetCurrentUserResponse =
+            with(getUserOutput) {
+                GetCurrentUserResponse(
+                    userId = user.id,
+                    name = user.name,
+                    profileUrl = user.profileUrl,
+                )
+            }
+    }
+}

--- a/src/test/kotlin/kr/wooco/woocobe/user/domain/usecase/GetUserUseCaseTest.kt
+++ b/src/test/kotlin/kr/wooco/woocobe/user/domain/usecase/GetUserUseCaseTest.kt
@@ -1,0 +1,48 @@
+package kr.wooco.woocobe.user.domain.usecase
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import kr.wooco.woocobe.support.IntegrationTest
+import kr.wooco.woocobe.support.MysqlCleaner
+import kr.wooco.woocobe.user.infrastructure.storage.UserEntity
+import kr.wooco.woocobe.user.infrastructure.storage.UserJpaRepository
+
+@IntegrationTest
+class GetUserUseCaseTest(
+    private val getUserUseCase: GetUserUseCase,
+    private val userJpaRepository: UserJpaRepository,
+) : BehaviorSpec({
+    listeners(MysqlCleaner())
+
+    Given("유효한 input 값이 들어올 경우") {
+        val validUserId = 1234567890L
+
+        val input = GetUserInput(userId = validUserId)
+
+        When("해당 사용자가 존재할 때") {
+            val userEntity = UserEntity(
+                id = validUserId,
+                name = "홍인데요",
+                profileUrl = "url",
+            ).run(userJpaRepository::save)
+
+            val sut = getUserUseCase.execute(input)
+
+            Then("사용자 정보를 반환한다.") {
+                val user = sut.user
+                user.id shouldBe userEntity.id
+                user.name shouldBe userEntity.name
+                user.profileUrl shouldBe userEntity.profileUrl
+            }
+        }
+
+        When("해당 사용자가 존재하지 않을 때") {
+            Then("NotExistsUserException 오류가 발생한다.") {
+                shouldThrow<RuntimeException> {
+                    getUserUseCase.execute(input)
+                }
+            }
+        }
+    }
+})

--- a/src/test/kotlin/kr/wooco/woocobe/user/domain/usecase/UpdateUserUseCaseTest.kt
+++ b/src/test/kotlin/kr/wooco/woocobe/user/domain/usecase/UpdateUserUseCaseTest.kt
@@ -1,0 +1,39 @@
+package kr.wooco.woocobe.user.domain.usecase
+
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import kr.wooco.woocobe.support.IntegrationTest
+import kr.wooco.woocobe.support.MysqlCleaner
+import kr.wooco.woocobe.user.infrastructure.storage.UserEntity
+import kr.wooco.woocobe.user.infrastructure.storage.UserJpaRepository
+
+@IntegrationTest
+class UpdateUserUseCaseTest(
+    private val updateUserUseCase: UpdateUserUseCase,
+    private val userJpaRepository: UserJpaRepository,
+) : BehaviorSpec({
+    listeners(MysqlCleaner())
+
+    Given("유효한 input 값이 들어올 경우") {
+        val validUserId = 1234567890L
+        val updatedName = "홍이름바꿈"
+        val updatedProfileUrl = "url-hong"
+
+        val input = UpdateUserInput(userId = validUserId, name = updatedName, profileUrl = updatedProfileUrl)
+
+        When("존재하는 회원일 때") {
+            UserEntity(id = validUserId, name = "홍인데유", profileUrl = "url").run(userJpaRepository::save)
+
+            updateUserUseCase.execute(input)
+
+            Then("회원 정보가 변경된다.") {
+                val userEntities = userJpaRepository.findAll()
+                userEntities.size shouldBe 1
+
+                userEntities[0].id shouldBe validUserId
+                userEntities[0].name shouldBe updatedName
+                userEntities[0].profileUrl shouldBe updatedProfileUrl
+            }
+        }
+    }
+})


### PR DESCRIPTION
## 📝 개요

<!-- 이 PR의 목적과 관련된 정보를 간략히 설명합니다. -->

회원 도메인에서 필요한 기능을 추가합니다.

## ✨ 변경 사항

<!-- 코드나 기능의 주요 변경 사항을 설명 -->

- ✨ 회원 도메인 로직 추가
- ✨ 회원 API 컨트롤러 추가
- ✨ 회원 도메인 유즈 케이스 테스트 코드 추가

## 🔗 관련 이슈

<!-- 이 PR과 관련된 이슈 번호를 연결 (없으면 생략) -->

- closed #31 

## ℹ️ 참고 사항

<!-- 리뷰어가 알 필요가 있는 추가 정보나 문서, 참고 링크를 포함 (없으면 생략) -->

`save()`와 `update()` 메서드를 분리해놨는데 분리한 것이 뭔가 더 명확하게 보여주는 것 같아서 좋지만 뭔가 부족한(?) 애매한(?) 느낌이 듭니다..

infrastructure의 gateway 구현체는 DI로만 사용하기 때문에, 앞으로 개발시 `internal` 키워드를 달아주시는게 좋을 것 같습니다~