### PR TITLE
feat: 장소 및 장소 리뷰 관련 기능 추가

### DIFF
--- a/src/main/kotlin/kr/wooco/woocobe/place/domain/gateway/PlaceReviewStorageGateway.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/domain/gateway/PlaceReviewStorageGateway.kt
@@ -1,0 +1,17 @@
+package kr.wooco.woocobe.place.domain.gateway
+
+import kr.wooco.woocobe.place.domain.model.PlaceReview
+
+interface PlaceReviewStorageGateway {
+    fun save(placeReview: PlaceReview): PlaceReview
+
+    fun getByPlaceReviewId(placeReviewId: Long): PlaceReview?
+
+    fun getAllByPlaceId(placeId: Long): List<PlaceReview>
+
+    fun getAllByPlaceReviewIds(placeReviewId: List<Long>): List<PlaceReview>
+
+    fun getAllByUserId(userId: Long): List<PlaceReview>
+
+    fun deleteByPlaceReviewId(placeReviewId: Long)
+}

--- a/src/main/kotlin/kr/wooco/woocobe/place/domain/gateway/PlaceStorageGateway.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/domain/gateway/PlaceStorageGateway.kt
@@ -1,0 +1,11 @@
+package kr.wooco.woocobe.place.domain.gateway
+
+import kr.wooco.woocobe.place.domain.model.Place
+
+interface PlaceStorageGateway {
+    fun save(place: Place): Place
+
+    fun getByPlaceId(placeId: Long): Place?
+
+    fun existsByKakaoMapPlaceId(placeId: String): Boolean
+}

--- a/src/main/kotlin/kr/wooco/woocobe/place/domain/model/Place.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/domain/model/Place.kt
@@ -1,10 +1,7 @@
 package kr.wooco.woocobe.place.domain.model
 
-import kr.wooco.woocobe.user.domain.model.User
-
 class Place(
     val id: Long,
-    val user: User,
     val name: String,
     val latitude: Double,
     val longitude: Double,
@@ -31,7 +28,6 @@ class Place(
 
     companion object {
         fun register(
-            user: User,
             name: String,
             latitude: Double,
             longitude: Double,
@@ -40,7 +36,6 @@ class Place(
         ): Place =
             Place(
                 id = 0L,
-                user = user,
                 name = name,
                 latitude = latitude,
                 longitude = longitude,

--- a/src/main/kotlin/kr/wooco/woocobe/place/domain/model/Place.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/domain/model/Place.kt
@@ -1,0 +1,53 @@
+package kr.wooco.woocobe.place.domain.model
+
+import kr.wooco.woocobe.user.domain.model.User
+
+class Place(
+    val id: Long,
+    val user: User,
+    val name: String,
+    val latitude: Double,
+    val longitude: Double,
+    val address: String,
+    val kakaoMapPlaceId: String,
+    var averageRating: Double, // 평균 별점 로직 고려 중
+    var reviewCount: Long,
+    // 한줄평 통계 로직 고려 중
+) {
+    fun increaseReviewCount() =
+        apply {
+            reviewCount++
+        }
+
+    fun decreaseReviewCount() =
+        apply {
+            reviewCount--
+        }
+
+    fun updateAverageRating(rating: Double) =
+        apply {
+            averageRating = (averageRating * reviewCount + rating) / (reviewCount)
+        }
+
+    companion object {
+        fun register(
+            user: User,
+            name: String,
+            latitude: Double,
+            longitude: Double,
+            address: String,
+            kakaoMapPlaceId: String,
+        ): Place =
+            Place(
+                id = 0L,
+                user = user,
+                name = name,
+                latitude = latitude,
+                longitude = longitude,
+                address = address,
+                kakaoMapPlaceId = kakaoMapPlaceId,
+                averageRating = 0.0,
+                reviewCount = 0,
+            )
+    }
+}

--- a/src/main/kotlin/kr/wooco/woocobe/place/domain/model/PlaceOneLineReview.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/domain/model/PlaceOneLineReview.kt
@@ -1,0 +1,12 @@
+package kr.wooco.woocobe.place.domain.model
+
+class PlaceOneLineReview(
+    val content: String,
+) {
+    companion object {
+        fun from(content: String): PlaceOneLineReview =
+            PlaceOneLineReview(
+                content = content,
+            )
+    }
+}

--- a/src/main/kotlin/kr/wooco/woocobe/place/domain/model/PlaceReview.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/domain/model/PlaceReview.kt
@@ -10,18 +10,18 @@ class PlaceReview(
     val writeDateTime: LocalDateTime,
     var rating: Double,
     var content: String,
-    var oneLineReview: List<PlaceOneLineReview>,
+    var oneLineReviews: List<PlaceOneLineReview>,
     var imageUrl: String,
 ) {
     fun update(
         rating: Double,
         content: String,
-        oneLinenReview: List<String>,
+        oneLineReviews: List<String>,
         imageUrl: String,
     ) = apply {
         this.rating = rating
         this.content = content
-        this.oneLineReview = oneLinenReview.map { PlaceOneLineReview.from(it) }
+        this.oneLineReviews = oneLineReviews.map { PlaceOneLineReview.from(it) }
         this.imageUrl = imageUrl
     }
 
@@ -37,7 +37,7 @@ class PlaceReview(
             place: Place,
             rating: Double,
             content: String,
-            oneLinenReview: List<PlaceOneLineReview>,
+            oneLineReview: List<PlaceOneLineReview>,
             imageUrl: String,
         ): PlaceReview =
             PlaceReview(
@@ -47,7 +47,7 @@ class PlaceReview(
                 writeDateTime = LocalDateTime.now(),
                 rating = rating,
                 content = content,
-                oneLineReview = oneLinenReview.map { it },
+                oneLineReviews = oneLineReview.map { it },
                 imageUrl = imageUrl,
             )
     }

--- a/src/main/kotlin/kr/wooco/woocobe/place/domain/model/PlaceReview.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/domain/model/PlaceReview.kt
@@ -11,18 +11,18 @@ class PlaceReview(
     var rating: Double,
     var content: String,
     var oneLineReviews: List<PlaceOneLineReview>,
-    var imageUrl: String,
+    var imageUrls: List<String>,
 ) {
     fun update(
         rating: Double,
         content: String,
         oneLineReviews: List<String>,
-        imageUrl: String,
+        imageUrls: List<String>,
     ) = apply {
         this.rating = rating
         this.content = content
         this.oneLineReviews = oneLineReviews.map { PlaceOneLineReview.from(it) }
-        this.imageUrl = imageUrl
+        this.imageUrls = imageUrls
     }
 
     fun isWriter(targetId: Long): Boolean =
@@ -38,7 +38,7 @@ class PlaceReview(
             rating: Double,
             content: String,
             oneLineReview: List<PlaceOneLineReview>,
-            imageUrl: String,
+            imageUrls: List<String>,
         ): PlaceReview =
             PlaceReview(
                 id = 0L,
@@ -48,7 +48,7 @@ class PlaceReview(
                 rating = rating,
                 content = content,
                 oneLineReviews = oneLineReview.map { it },
-                imageUrl = imageUrl,
+                imageUrls = imageUrls,
             )
     }
 }

--- a/src/main/kotlin/kr/wooco/woocobe/place/domain/model/PlaceReview.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/domain/model/PlaceReview.kt
@@ -33,7 +33,7 @@ class PlaceReview(
             place: Place,
             rating: Double,
             content: String,
-            oneLineReview: List<PlaceOneLineReview>,
+            oneLineReview: List<String>,
             imageUrls: List<String>,
         ): PlaceReview =
             PlaceReview(
@@ -43,7 +43,7 @@ class PlaceReview(
                 writeDateTime = LocalDateTime.now(),
                 rating = rating,
                 content = content,
-                oneLineReviews = oneLineReview,
+                oneLineReviews = oneLineReview.map { PlaceOneLineReview.from(it) },
                 imageUrls = imageUrls,
             )
     }

--- a/src/main/kotlin/kr/wooco/woocobe/place/domain/model/PlaceReview.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/domain/model/PlaceReview.kt
@@ -25,11 +25,7 @@ class PlaceReview(
         this.imageUrls = imageUrls
     }
 
-    fun isWriter(targetId: Long): Boolean =
-        when (user.id == targetId) {
-            true -> true
-            else -> throw RuntimeException()
-        }
+    fun isWriter(targetId: Long): Boolean = user.id == targetId
 
     companion object {
         fun register(

--- a/src/main/kotlin/kr/wooco/woocobe/place/domain/model/PlaceReview.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/domain/model/PlaceReview.kt
@@ -1,0 +1,54 @@
+package kr.wooco.woocobe.place.domain.model
+
+import kr.wooco.woocobe.user.domain.model.User
+import java.time.LocalDateTime
+
+class PlaceReview(
+    val id: Long,
+    val user: User,
+    val place: Place,
+    val writeDateTime: LocalDateTime,
+    var rating: Double,
+    var content: String,
+    var oneLineReview: List<PlaceOneLineReview>,
+    var imageUrl: String,
+) {
+    fun update(
+        rating: Double,
+        content: String,
+        oneLinenReview: List<String>,
+        imageUrl: String,
+    ) = apply {
+        this.rating = rating
+        this.content = content
+        this.oneLineReview = oneLinenReview.map { PlaceOneLineReview.from(it) }
+        this.imageUrl = imageUrl
+    }
+
+    fun isWriter(targetId: Long): Boolean =
+        when (user.id == targetId) {
+            true -> true
+            else -> throw RuntimeException()
+        }
+
+    companion object {
+        fun register(
+            user: User,
+            place: Place,
+            rating: Double,
+            content: String,
+            oneLinenReview: List<PlaceOneLineReview>,
+            imageUrl: String,
+        ): PlaceReview =
+            PlaceReview(
+                id = 0L,
+                user = user,
+                place = place,
+                writeDateTime = LocalDateTime.now(),
+                rating = rating,
+                content = content,
+                oneLineReview = oneLinenReview.map { it },
+                imageUrl = imageUrl,
+            )
+    }
+}

--- a/src/main/kotlin/kr/wooco/woocobe/place/domain/model/PlaceReview.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/domain/model/PlaceReview.kt
@@ -47,7 +47,7 @@ class PlaceReview(
                 writeDateTime = LocalDateTime.now(),
                 rating = rating,
                 content = content,
-                oneLineReviews = oneLineReview.map { it },
+                oneLineReviews = oneLineReview,
                 imageUrls = imageUrls,
             )
     }

--- a/src/main/kotlin/kr/wooco/woocobe/place/domain/usecase/AddPlaceReviewUseCase.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/domain/usecase/AddPlaceReviewUseCase.kt
@@ -1,0 +1,43 @@
+package kr.wooco.woocobe.place.domain.usecase
+
+import kr.wooco.woocobe.common.domain.UseCase
+import kr.wooco.woocobe.place.domain.gateway.PlaceReviewStorageGateway
+import kr.wooco.woocobe.place.domain.gateway.PlaceStorageGateway
+import kr.wooco.woocobe.place.domain.model.PlaceOneLineReview
+import kr.wooco.woocobe.place.domain.model.PlaceReview
+import kr.wooco.woocobe.user.domain.model.User
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+data class AddPlaceReviewInput(
+    val userId: Long,
+    val placeId: Long,
+    val rating: Double,
+    val content: String,
+    val oneLineReview: List<PlaceOneLineReview>,
+    val imageUrl: String,
+)
+
+@Service
+class AddPlaceReviewUseCase(
+    private val placeReviewStorageGateway: PlaceReviewStorageGateway,
+    private val placeStorageGateway: PlaceStorageGateway,
+) : UseCase<AddPlaceReviewInput, Unit> {
+    @Transactional
+    override fun execute(input: AddPlaceReviewInput) {
+        val user = User.register(userId = input.userId)
+        val place = placeStorageGateway.getByPlaceId(input.placeId)
+            ?: throw RuntimeException()
+
+        PlaceReview
+            .register(
+                user = user,
+                place = place,
+                rating = input.rating,
+                content = input.content,
+                oneLinenReview = input.oneLineReview,
+                imageUrl = input.imageUrl,
+            ).also(placeReviewStorageGateway::save)
+        place.increaseReviewCount()
+    }
+}

--- a/src/main/kotlin/kr/wooco/woocobe/place/domain/usecase/AddPlaceReviewUseCase.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/domain/usecase/AddPlaceReviewUseCase.kt
@@ -14,7 +14,7 @@ data class AddPlaceReviewInput(
     val placeId: Long,
     val rating: Double,
     val content: String,
-    val oneLineReview: List<PlaceOneLineReview>,
+    val oneLineReviews: List<PlaceOneLineReview>,
     val imageUrl: String,
 )
 
@@ -35,7 +35,7 @@ class AddPlaceReviewUseCase(
                 place = place,
                 rating = input.rating,
                 content = input.content,
-                oneLinenReview = input.oneLineReview,
+                oneLineReview = input.oneLineReviews,
                 imageUrl = input.imageUrl,
             ).also(placeReviewStorageGateway::save)
         place.increaseReviewCount()

--- a/src/main/kotlin/kr/wooco/woocobe/place/domain/usecase/AddPlaceReviewUseCase.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/domain/usecase/AddPlaceReviewUseCase.kt
@@ -3,7 +3,6 @@ package kr.wooco.woocobe.place.domain.usecase
 import kr.wooco.woocobe.common.domain.UseCase
 import kr.wooco.woocobe.place.domain.gateway.PlaceReviewStorageGateway
 import kr.wooco.woocobe.place.domain.gateway.PlaceStorageGateway
-import kr.wooco.woocobe.place.domain.model.PlaceOneLineReview
 import kr.wooco.woocobe.place.domain.model.PlaceReview
 import kr.wooco.woocobe.user.domain.model.User
 import org.springframework.stereotype.Service
@@ -14,7 +13,7 @@ data class AddPlaceReviewInput(
     val placeId: Long,
     val rating: Double,
     val content: String,
-    val oneLineReviews: List<PlaceOneLineReview>,
+    val oneLineReviews: List<String>,
     val imageUrls: List<String>,
 )
 

--- a/src/main/kotlin/kr/wooco/woocobe/place/domain/usecase/AddPlaceReviewUseCase.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/domain/usecase/AddPlaceReviewUseCase.kt
@@ -15,7 +15,7 @@ data class AddPlaceReviewInput(
     val rating: Double,
     val content: String,
     val oneLineReviews: List<PlaceOneLineReview>,
-    val imageUrl: String,
+    val imageUrls: List<String>,
 )
 
 @Service
@@ -36,8 +36,10 @@ class AddPlaceReviewUseCase(
                 rating = input.rating,
                 content = input.content,
                 oneLineReview = input.oneLineReviews,
-                imageUrl = input.imageUrl,
+                imageUrls = input.imageUrls,
             ).also(placeReviewStorageGateway::save)
         place.increaseReviewCount()
+
+        placeStorageGateway.save(place)
     }
 }

--- a/src/main/kotlin/kr/wooco/woocobe/place/domain/usecase/AddPlaceUseCase.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/domain/usecase/AddPlaceUseCase.kt
@@ -23,7 +23,9 @@ class AddPlaceUseCase(
     @Transactional
     override fun execute(input: AddPlaceUseCaseInput) {
         when {
-            !placeStorageGateway.existsByKakaoMapPlaceId(input.kakaoMapPlaceId) -> throw RuntimeException()
+            placeStorageGateway
+                .existsByKakaoMapPlaceId(input.kakaoMapPlaceId)
+                .not() -> throw RuntimeException()
         }
 
         val user = User.register(userId = input.userId)

--- a/src/main/kotlin/kr/wooco/woocobe/place/domain/usecase/AddPlaceUseCase.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/domain/usecase/AddPlaceUseCase.kt
@@ -1,0 +1,40 @@
+package kr.wooco.woocobe.place.domain.usecase
+
+import kr.wooco.woocobe.common.domain.UseCase
+import kr.wooco.woocobe.place.domain.gateway.PlaceStorageGateway
+import kr.wooco.woocobe.place.domain.model.Place
+import kr.wooco.woocobe.user.domain.model.User
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+data class AddPlaceUseCaseInput(
+    val userId: Long,
+    val name: String,
+    val latitude: Double,
+    val longitude: Double,
+    val address: String,
+    val kakaoMapPlaceId: String,
+)
+
+@Service
+class AddPlaceUseCase(
+    private val placeStorageGateway: PlaceStorageGateway,
+) : UseCase<AddPlaceUseCaseInput, Unit> {
+    @Transactional
+    override fun execute(input: AddPlaceUseCaseInput) {
+        when {
+            !placeStorageGateway.existsByKakaoMapPlaceId(input.kakaoMapPlaceId) -> throw RuntimeException()
+        }
+
+        val user = User.register(userId = input.userId)
+        Place
+            .register(
+                user = user,
+                name = input.name,
+                latitude = input.latitude,
+                longitude = input.longitude,
+                address = input.address,
+                kakaoMapPlaceId = input.kakaoMapPlaceId,
+            ).also(placeStorageGateway::save)
+    }
+}

--- a/src/main/kotlin/kr/wooco/woocobe/place/domain/usecase/AddPlaceUseCase.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/domain/usecase/AddPlaceUseCase.kt
@@ -3,12 +3,10 @@ package kr.wooco.woocobe.place.domain.usecase
 import kr.wooco.woocobe.common.domain.UseCase
 import kr.wooco.woocobe.place.domain.gateway.PlaceStorageGateway
 import kr.wooco.woocobe.place.domain.model.Place
-import kr.wooco.woocobe.user.domain.model.User
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
 data class AddPlaceUseCaseInput(
-    val userId: Long,
     val name: String,
     val latitude: Double,
     val longitude: Double,
@@ -28,10 +26,8 @@ class AddPlaceUseCase(
                 .not() -> throw RuntimeException()
         }
 
-        val user = User.register(userId = input.userId)
         Place
             .register(
-                user = user,
                 name = input.name,
                 latitude = input.latitude,
                 longitude = input.longitude,

--- a/src/main/kotlin/kr/wooco/woocobe/place/domain/usecase/DeletePlaceReviewUseCase.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/domain/usecase/DeletePlaceReviewUseCase.kt
@@ -2,6 +2,7 @@ package kr.wooco.woocobe.place.domain.usecase
 
 import kr.wooco.woocobe.common.domain.UseCase
 import kr.wooco.woocobe.place.domain.gateway.PlaceReviewStorageGateway
+import kr.wooco.woocobe.place.domain.gateway.PlaceStorageGateway
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -13,6 +14,7 @@ data class DeletePlaceReviewInput(
 @Service
 class DeletePlaceReviewUseCase(
     private val placeReviewStorageGateway: PlaceReviewStorageGateway,
+    private val placeStorageGateway: PlaceStorageGateway,
 ) : UseCase<DeletePlaceReviewInput, Unit> {
     @Transactional
     override fun execute(input: DeletePlaceReviewInput) {
@@ -26,5 +28,7 @@ class DeletePlaceReviewUseCase(
         placeReviewStorageGateway.deleteByPlaceReviewId(placeReviewId = placeReview.id)
 
         placeReview.place.decreaseReviewCount()
+
+        placeStorageGateway.save(placeReview.place)
     }
 }

--- a/src/main/kotlin/kr/wooco/woocobe/place/domain/usecase/DeletePlaceReviewUseCase.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/domain/usecase/DeletePlaceReviewUseCase.kt
@@ -1,0 +1,31 @@
+package kr.wooco.woocobe.place.domain.usecase
+
+import kr.wooco.woocobe.common.domain.UseCase
+import kr.wooco.woocobe.place.domain.gateway.PlaceReviewStorageGateway
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+data class DeletePlaceReviewInput(
+    val userId: Long,
+    val placeReviewId: Long,
+)
+
+@Service
+class DeletePlaceReviewUseCase(
+    private val placeReviewStorageGateway: PlaceReviewStorageGateway,
+) : UseCase<DeletePlaceReviewInput, Unit> {
+    @Transactional
+    override fun execute(input: DeletePlaceReviewInput) {
+        val placeReview = placeReviewStorageGateway
+            .getByPlaceReviewId(input.placeReviewId)
+            ?: throw RuntimeException()
+
+        when {
+            placeReview.isWriter(input.userId).not() -> throw RuntimeException()
+        }
+
+        placeReviewStorageGateway.deleteByPlaceReviewId(placeReviewId = placeReview.id)
+
+        placeReview.place.decreaseReviewCount()
+    }
+}

--- a/src/main/kotlin/kr/wooco/woocobe/place/domain/usecase/DeletePlaceReviewUseCase.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/domain/usecase/DeletePlaceReviewUseCase.kt
@@ -16,8 +16,7 @@ class DeletePlaceReviewUseCase(
 ) : UseCase<DeletePlaceReviewInput, Unit> {
     @Transactional
     override fun execute(input: DeletePlaceReviewInput) {
-        val placeReview = placeReviewStorageGateway
-            .getByPlaceReviewId(input.placeReviewId)
+        val placeReview = placeReviewStorageGateway.getByPlaceReviewId(input.placeReviewId)
             ?: throw RuntimeException()
 
         when {

--- a/src/main/kotlin/kr/wooco/woocobe/place/domain/usecase/GetAllPlaceReviewUseCase.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/domain/usecase/GetAllPlaceReviewUseCase.kt
@@ -1,0 +1,28 @@
+package kr.wooco.woocobe.place.domain.usecase
+
+import kr.wooco.woocobe.common.domain.UseCase
+import kr.wooco.woocobe.place.domain.gateway.PlaceReviewStorageGateway
+import kr.wooco.woocobe.place.domain.model.PlaceReview
+import org.springframework.stereotype.Service
+
+data class GetAllPlaceReviewInput(
+    val placeId: Long,
+)
+
+data class GetAllPlaceReviewOutput(
+    val placeReviewList: List<PlaceReview>,
+)
+
+@Service
+class GetAllPlaceReviewUseCase(
+    private val placeReviewStorageGateway: PlaceReviewStorageGateway,
+) : UseCase<GetAllPlaceReviewInput, GetAllPlaceReviewOutput> {
+    override fun execute(input: GetAllPlaceReviewInput): GetAllPlaceReviewOutput {
+        val placeReviewList =
+            placeReviewStorageGateway.getAllByPlaceId(input.placeId)
+
+        return GetAllPlaceReviewOutput(
+            placeReviewList = placeReviewList,
+        )
+    }
+}

--- a/src/main/kotlin/kr/wooco/woocobe/place/domain/usecase/GetAllPlaceReviewUseCase.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/domain/usecase/GetAllPlaceReviewUseCase.kt
@@ -10,7 +10,7 @@ data class GetAllPlaceReviewInput(
 )
 
 data class GetAllPlaceReviewOutput(
-    val placeReviewList: List<PlaceReview>,
+    val placeReviews: List<PlaceReview>,
 )
 
 @Service
@@ -18,11 +18,10 @@ class GetAllPlaceReviewUseCase(
     private val placeReviewStorageGateway: PlaceReviewStorageGateway,
 ) : UseCase<GetAllPlaceReviewInput, GetAllPlaceReviewOutput> {
     override fun execute(input: GetAllPlaceReviewInput): GetAllPlaceReviewOutput {
-        val placeReviewList =
-            placeReviewStorageGateway.getAllByPlaceId(input.placeId)
+        val placeReviews = placeReviewStorageGateway.getAllByPlaceId(input.placeId)
 
         return GetAllPlaceReviewOutput(
-            placeReviewList = placeReviewList,
+            placeReviews = placeReviews,
         )
     }
 }

--- a/src/main/kotlin/kr/wooco/woocobe/place/domain/usecase/GetPlaceReviewUseCase.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/domain/usecase/GetPlaceReviewUseCase.kt
@@ -1,0 +1,28 @@
+package kr.wooco.woocobe.place.domain.usecase
+
+import kr.wooco.woocobe.common.domain.UseCase
+import kr.wooco.woocobe.place.domain.gateway.PlaceReviewStorageGateway
+import kr.wooco.woocobe.place.domain.model.PlaceReview
+import org.springframework.stereotype.Service
+
+data class GetPlaceReviewInput(
+    val placeReviewId: Long,
+)
+
+data class GetPlaceReviewOutput(
+    val placeReview: PlaceReview,
+)
+
+@Service
+class GetPlaceReviewUseCase(
+    private val placeReviewStorageGateway: PlaceReviewStorageGateway,
+) : UseCase<GetPlaceReviewInput, GetPlaceReviewOutput> {
+    override fun execute(input: GetPlaceReviewInput): GetPlaceReviewOutput {
+        val placeReview = placeReviewStorageGateway.getByPlaceReviewId(input.placeReviewId)
+            ?: throw RuntimeException()
+
+        return GetPlaceReviewOutput(
+            placeReview = placeReview,
+        )
+    }
+}

--- a/src/main/kotlin/kr/wooco/woocobe/place/domain/usecase/GetPlaceUseCase.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/domain/usecase/GetPlaceUseCase.kt
@@ -6,7 +6,6 @@ import kr.wooco.woocobe.place.domain.model.Place
 import org.springframework.stereotype.Service
 
 data class GetPlaceInput(
-    val userId: Long?,
     val placeId: Long,
 )
 

--- a/src/main/kotlin/kr/wooco/woocobe/place/domain/usecase/GetPlaceUseCase.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/domain/usecase/GetPlaceUseCase.kt
@@ -1,0 +1,29 @@
+package kr.wooco.woocobe.place.domain.usecase
+
+import kr.wooco.woocobe.common.domain.UseCase
+import kr.wooco.woocobe.place.domain.gateway.PlaceStorageGateway
+import kr.wooco.woocobe.place.domain.model.Place
+import org.springframework.stereotype.Service
+
+data class GetPlaceInput(
+    val userId: Long?,
+    val placeId: Long,
+)
+
+data class GetPlaceOutPut(
+    val place: Place,
+)
+
+@Service
+class GetPlaceUseCase(
+    private val placeStorageGateway: PlaceStorageGateway,
+) : UseCase<GetPlaceInput, GetPlaceOutPut> {
+    override fun execute(input: GetPlaceInput): GetPlaceOutPut {
+        val place = placeStorageGateway.getByPlaceId(input.placeId)
+            ?: throw RuntimeException()
+
+        return GetPlaceOutPut(
+            place = place,
+        )
+    }
+}

--- a/src/main/kotlin/kr/wooco/woocobe/place/domain/usecase/GetUserAllPlaceReviewUseCase.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/domain/usecase/GetUserAllPlaceReviewUseCase.kt
@@ -10,7 +10,7 @@ data class GetUserAllPlaceReviewInput(
 )
 
 data class GetUserAllPlaceReviewOutput(
-    val placeReviewList: List<PlaceReview>,
+    val placeReviews: List<PlaceReview>,
 )
 
 @Service
@@ -18,10 +18,10 @@ class GetUserAllPlaceReviewUseCase(
     private val placeReviewStorageGateway: PlaceReviewStorageGateway,
 ) : UseCase<GetUserAllPlaceReviewInput, GetUserAllPlaceReviewOutput> {
     override fun execute(input: GetUserAllPlaceReviewInput): GetUserAllPlaceReviewOutput {
-        val placeReviewList = placeReviewStorageGateway.getAllByUserId(input.userId)
+        val placeReviews = placeReviewStorageGateway.getAllByUserId(input.userId)
 
         return GetUserAllPlaceReviewOutput(
-            placeReviewList = placeReviewList,
+            placeReviews = placeReviews,
         )
     }
 }

--- a/src/main/kotlin/kr/wooco/woocobe/place/domain/usecase/GetUserAllPlaceReviewUseCase.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/domain/usecase/GetUserAllPlaceReviewUseCase.kt
@@ -1,0 +1,27 @@
+package kr.wooco.woocobe.place.domain.usecase
+
+import kr.wooco.woocobe.common.domain.UseCase
+import kr.wooco.woocobe.place.domain.gateway.PlaceReviewStorageGateway
+import kr.wooco.woocobe.place.domain.model.PlaceReview
+import org.springframework.stereotype.Service
+
+data class GetUserAllPlaceReviewInput(
+    val userId: Long,
+)
+
+data class GetUserAllPlaceReviewOutput(
+    val placeReviewList: List<PlaceReview>,
+)
+
+@Service
+class GetUserAllPlaceReviewUseCase(
+    private val placeReviewStorageGateway: PlaceReviewStorageGateway,
+) : UseCase<GetUserAllPlaceReviewInput, GetUserAllPlaceReviewOutput> {
+    override fun execute(input: GetUserAllPlaceReviewInput): GetUserAllPlaceReviewOutput {
+        val placeReviewList = placeReviewStorageGateway.getAllByUserId(input.userId)
+
+        return GetUserAllPlaceReviewOutput(
+            placeReviewList = placeReviewList,
+        )
+    }
+}

--- a/src/main/kotlin/kr/wooco/woocobe/place/domain/usecase/UpdatePlaceReviewUseCase.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/domain/usecase/UpdatePlaceReviewUseCase.kt
@@ -1,0 +1,38 @@
+package kr.wooco.woocobe.place.domain.usecase
+
+import kr.wooco.woocobe.common.domain.UseCase
+import kr.wooco.woocobe.place.domain.gateway.PlaceReviewStorageGateway
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+data class UpdatePlaceReviewInput(
+    val userId: Long,
+    val placeReviewId: Long,
+    val rating: Double,
+    var content: String,
+    var oneLineReview: List<String>,
+    var imageUrl: String,
+)
+
+@Service
+class UpdatePlaceReviewUseCase(
+    private val placeReviewStorageGateway: PlaceReviewStorageGateway,
+) : UseCase<UpdatePlaceReviewInput, Unit> {
+    @Transactional
+    override fun execute(input: UpdatePlaceReviewInput) {
+        val placeReview = placeReviewStorageGateway.getByPlaceReviewId(input.placeReviewId)
+            ?: throw RuntimeException()
+
+        when {
+            placeReview.isWriter(input.userId).not() -> throw RuntimeException()
+        }
+
+        placeReview
+            .update(
+                rating = input.rating,
+                content = input.content,
+                oneLinenReview = input.oneLineReview,
+                imageUrl = input.imageUrl,
+            ).also(placeReviewStorageGateway::save)
+    }
+}

--- a/src/main/kotlin/kr/wooco/woocobe/place/domain/usecase/UpdatePlaceReviewUseCase.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/domain/usecase/UpdatePlaceReviewUseCase.kt
@@ -10,8 +10,8 @@ data class UpdatePlaceReviewInput(
     val placeReviewId: Long,
     val rating: Double,
     var content: String,
-    var oneLineReview: List<String>,
-    var imageUrl: String,
+    var oneLineReviews: List<String>,
+    var imageUrls: List<String>,
 )
 
 @Service
@@ -31,8 +31,8 @@ class UpdatePlaceReviewUseCase(
             .update(
                 rating = input.rating,
                 content = input.content,
-                oneLinenReview = input.oneLineReview,
-                imageUrl = input.imageUrl,
+                oneLineReviews = input.oneLineReviews,
+                imageUrls = input.imageUrls,
             ).also(placeReviewStorageGateway::save)
     }
 }

--- a/src/main/kotlin/kr/wooco/woocobe/place/domain/usecase/ValidateReviewWriterUseCase.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/domain/usecase/ValidateReviewWriterUseCase.kt
@@ -1,0 +1,22 @@
+package kr.wooco.woocobe.place.domain.usecase
+
+import kr.wooco.woocobe.common.domain.UseCase
+import kr.wooco.woocobe.place.domain.gateway.PlaceReviewStorageGateway
+
+data class ValidateReviewWriterInput(
+    val userId: Long,
+    val placeReviewId: Long,
+)
+
+class ValidateReviewWriterUseCase(
+    private val placeReviewStorageGateway: PlaceReviewStorageGateway,
+) : UseCase<ValidateReviewWriterInput, Unit> {
+    override fun execute(input: ValidateReviewWriterInput) {
+        val placeReview = placeReviewStorageGateway.getByPlaceReviewId(input.placeReviewId)
+            ?: throw RuntimeException()
+
+        when {
+            placeReview.isWriter(input.userId).not() -> throw RuntimeException()
+        }
+    }
+}

--- a/src/main/kotlin/kr/wooco/woocobe/place/infrastructure/gateway/JpaPlaceReviewStorageGateway.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/infrastructure/gateway/JpaPlaceReviewStorageGateway.kt
@@ -21,7 +21,7 @@ class JpaPlaceReviewStorageGateway(
     override fun save(placeReview: PlaceReview): PlaceReview {
         val placeReviewEntity = placeReviewJpaRepository.save(PlaceReviewEntity.from(placeReview))
         if (placeReview.id == 0L) {
-            placeReview.oneLineReview
+            placeReview.oneLineReviews
                 .map {
                     PlaceOneLineReviewEntity.of(
                         placeReviewId = placeReviewEntity.id!!,

--- a/src/main/kotlin/kr/wooco/woocobe/place/infrastructure/gateway/JpaPlaceReviewStorageGateway.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/infrastructure/gateway/JpaPlaceReviewStorageGateway.kt
@@ -1,0 +1,122 @@
+package kr.wooco.woocobe.place.infrastructure.gateway
+
+import kr.wooco.woocobe.place.domain.gateway.PlaceReviewStorageGateway
+import kr.wooco.woocobe.place.domain.model.PlaceReview
+import kr.wooco.woocobe.place.infrastructure.storage.PlaceJpaRepository
+import kr.wooco.woocobe.place.infrastructure.storage.PlaceOneLineReviewEntity
+import kr.wooco.woocobe.place.infrastructure.storage.PlaceOneLineReviewJpaRepository
+import kr.wooco.woocobe.place.infrastructure.storage.PlaceReviewEntity
+import kr.wooco.woocobe.place.infrastructure.storage.PlaceReviewJpaRepository
+import kr.wooco.woocobe.user.infrastructure.storage.UserJpaRepository
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Component
+
+@Component
+class JpaPlaceReviewStorageGateway(
+    private val userJpaRepository: UserJpaRepository,
+    private val placeJpaRepository: PlaceJpaRepository,
+    private val placeReviewJpaRepository: PlaceReviewJpaRepository,
+    private val placeOneLineReviewJpaRepository: PlaceOneLineReviewJpaRepository,
+) : PlaceReviewStorageGateway {
+    override fun save(placeReview: PlaceReview): PlaceReview {
+        val placeReviewEntity = placeReviewJpaRepository.save(PlaceReviewEntity.from(placeReview))
+        if (placeReview.id == 0L) {
+            placeReview.oneLineReview
+                .map {
+                    PlaceOneLineReviewEntity.of(
+                        placeReviewId = placeReviewEntity.id!!,
+                        content = it.content,
+                    )
+                }.also(placeOneLineReviewJpaRepository::saveAll)
+        }
+
+        return placeReview
+    }
+
+    override fun getByPlaceReviewId(placeReviewId: Long): PlaceReview? =
+        placeReviewJpaRepository.findByIdOrNull(placeReviewId)?.let { placeReviewEntity ->
+            val userEntity = userJpaRepository.findByIdOrNull(placeReviewEntity.userId)!!
+            val placeEntity = placeJpaRepository.findByIdOrNull(placeReviewEntity.placeId)!!
+
+            placeReviewEntity.toDomain(
+                user = userEntity.toDomain(),
+                place = placeEntity.toDomain(userEntity.toDomain()),
+                placeOneLineReview = placeOneLineReviewJpaRepository
+                    .findAllByPlaceReviewIdOrderByCreatedAt(placeReviewEntity.id!!)
+                    .map { it.toDomain() },
+            )
+        }
+
+    override fun getAllByPlaceReviewIds(placeReviewId: List<Long>): List<PlaceReview> =
+        placeReviewJpaRepository
+            .findAllByIdInOrderByCreatedAt(placeReviewId)
+            .run {
+                val userEntities = userJpaRepository.findAllById(map { it.userId })
+                val placeEntities = placeJpaRepository.findAllById(map { it.placeId })
+                val placeOneLineReviewEntities = placeOneLineReviewJpaRepository
+                    .findAllByPlaceReviewIdInOrderByCreatedAt(map { it.id!! })
+                map { placeReviewEntity ->
+                    placeReviewEntity.toDomain(
+                        user = userEntities.find { placeReviewEntity.userId == it.id }!!.toDomain(),
+                        place = placeEntities
+                            .find { placeReviewEntity.placeId == it.id }!!
+                            .toDomain(
+                                user = userEntities
+                                    .find { placeReviewEntity.userId == it.id }!!
+                                    .toDomain(),
+                            ),
+                        placeOneLineReview = placeOneLineReviewEntities
+                            .filter { placeReviewEntity.id == it.placeReviewId }
+                            .map { it.toDomain() },
+                    )
+                }
+            }
+
+    override fun getAllByPlaceId(placeId: Long): List<PlaceReview> =
+        placeReviewJpaRepository
+            .findAllByPlaceIdOrderByCreatedAt(placeId)
+            .run {
+                val userEntity = userJpaRepository.findAllById(map { it.userId })
+                val placeOneLineReviewEntity =
+                    placeOneLineReviewJpaRepository.findAllByPlaceReviewIdInOrderByCreatedAt(map { it.id!! })
+                map { placeReviewEntity ->
+                    placeReviewEntity.toDomain(
+                        user = userEntity.find { placeReviewEntity.userId == it.id }!!.toDomain(),
+                        place = placeJpaRepository
+                            .findByIdOrNull(placeReviewEntity.placeId)!!
+                            .toDomain(
+                                user = userEntity
+                                    .find { placeReviewEntity.userId == it.id }!!
+                                    .toDomain(),
+                            ),
+                        placeOneLineReview = placeOneLineReviewEntity
+                            .filter { placeReviewEntity.id == it.placeReviewId }
+                            .map { it.toDomain() },
+                    )
+                }
+            }
+
+    override fun getAllByUserId(userId: Long): List<PlaceReview> =
+        placeReviewJpaRepository
+            .findAllByUserIdOrderByCreatedAt(userId)
+            .run {
+                val userEntity = userJpaRepository.findByIdOrNull(userId)!!
+                val placeOneLineReviewEntity =
+                    placeOneLineReviewJpaRepository.findAllByPlaceReviewIdInOrderByCreatedAt(map { it.id!! })
+                map { placeReviewEntity ->
+                    placeReviewEntity.toDomain(
+                        user = userEntity.toDomain(),
+                        place = placeJpaRepository
+                            .findByIdOrNull(placeReviewEntity.placeId)!!
+                            .toDomain(
+                                user = userEntity.toDomain(),
+                            ),
+                        placeOneLineReview = placeOneLineReviewEntity
+                            .filter { placeReviewEntity.id == it.placeReviewId }
+                            .map { it.toDomain() },
+                    )
+                }
+            }
+
+    override fun deleteByPlaceReviewId(placeReviewId: Long) = placeReviewJpaRepository.deleteById(placeReviewId)
+}

--- a/src/main/kotlin/kr/wooco/woocobe/place/infrastructure/gateway/JpaPlaceStorageGateway.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/infrastructure/gateway/JpaPlaceStorageGateway.kt
@@ -19,12 +19,7 @@ class JpaPlaceStorageGateway(
         return place
     }
 
-    override fun getByPlaceId(placeId: Long): Place? =
-        placeJpaRepository.findByIdOrNull(placeId)?.let { placeEntity ->
-            placeEntity.toDomain(
-                user = userJpaRepository.findByIdOrNull(placeEntity.userId)!!.toDomain(),
-            )
-        }
+    override fun getByPlaceId(placeId: Long): Place? = placeJpaRepository.findByIdOrNull(placeId)?.toDomain()
 
     override fun existsByKakaoMapPlaceId(placeId: String): Boolean = placeJpaRepository.existsByKakaoMapPlaceId(placeId)
 }

--- a/src/main/kotlin/kr/wooco/woocobe/place/infrastructure/gateway/JpaPlaceStorageGateway.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/infrastructure/gateway/JpaPlaceStorageGateway.kt
@@ -14,10 +14,7 @@ class JpaPlaceStorageGateway(
     private val placeJpaRepository: PlaceJpaRepository,
 ) : PlaceStorageGateway {
     override fun save(place: Place): Place {
-        val placeEntity = placeJpaRepository.save(PlaceEntity.from(place))
-        if (place.id == 0L) {
-            placeJpaRepository.save(placeEntity)
-        }
+        placeJpaRepository.save(PlaceEntity.from(place))
 
         return place
     }

--- a/src/main/kotlin/kr/wooco/woocobe/place/infrastructure/gateway/JpaPlaceStorageGateway.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/infrastructure/gateway/JpaPlaceStorageGateway.kt
@@ -1,0 +1,33 @@
+package kr.wooco.woocobe.place.infrastructure.gateway
+
+import kr.wooco.woocobe.place.domain.gateway.PlaceStorageGateway
+import kr.wooco.woocobe.place.domain.model.Place
+import kr.wooco.woocobe.place.infrastructure.storage.PlaceEntity
+import kr.wooco.woocobe.place.infrastructure.storage.PlaceJpaRepository
+import kr.wooco.woocobe.user.infrastructure.storage.UserJpaRepository
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Component
+
+@Component
+class JpaPlaceStorageGateway(
+    private val userJpaRepository: UserJpaRepository,
+    private val placeJpaRepository: PlaceJpaRepository,
+) : PlaceStorageGateway {
+    override fun save(place: Place): Place {
+        val placeEntity = placeJpaRepository.save(PlaceEntity.from(place))
+        if (place.id == 0L) {
+            placeJpaRepository.save(placeEntity)
+        }
+
+        return place
+    }
+
+    override fun getByPlaceId(placeId: Long): Place? =
+        placeJpaRepository.findByIdOrNull(placeId)?.let { placeEntity ->
+            placeEntity.toDomain(
+                user = userJpaRepository.findByIdOrNull(placeEntity.userId)!!.toDomain(),
+            )
+        }
+
+    override fun existsByKakaoMapPlaceId(placeId: String): Boolean = placeJpaRepository.existsByKakaoMapPlaceId(placeId)
+}

--- a/src/main/kotlin/kr/wooco/woocobe/place/infrastructure/storage/PlaceEntity.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/infrastructure/storage/PlaceEntity.kt
@@ -1,0 +1,64 @@
+package kr.wooco.woocobe.place.infrastructure.storage
+
+import io.hypersistence.utils.hibernate.id.Tsid
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import kr.wooco.woocobe.common.storage.BaseTimeEntity
+import kr.wooco.woocobe.place.domain.model.Place
+import kr.wooco.woocobe.user.domain.model.User
+
+@Entity
+@Table(name = "places")
+class PlaceEntity(
+    @Column(name = "review_count", nullable = false)
+    val reviewCount: Long,
+    @Column(name = "average_rating", nullable = false)
+    val averageRating: Double,
+    @Column(name = "kakao_map_place_id", nullable = false)
+    val kakaoMapPlaceId: String,
+    @Column(name = "longitude", nullable = false)
+    val longitude: Double,
+    @Column(name = "latitude", nullable = false)
+    val latitude: Double,
+    @Column(name = "address", nullable = false)
+    val address: String,
+    @Column(name = "name", nullable = false)
+    val name: String,
+    @Column(name = "user_id", nullable = false)
+    val userId: Long,
+    @Id @Tsid
+    @Column(name = "place_id", nullable = false)
+    val id: Long? = 0L,
+) : BaseTimeEntity() {
+    fun toDomain(user: User): Place =
+        Place(
+            id = id!!,
+            user = user,
+            name = name,
+            latitude = latitude,
+            longitude = longitude,
+            address = address,
+            kakaoMapPlaceId = kakaoMapPlaceId,
+            averageRating = averageRating,
+            reviewCount = reviewCount,
+        )
+
+    companion object {
+        fun from(place: Place): PlaceEntity =
+            with(place) {
+                PlaceEntity(
+                    id = id,
+                    userId = user.id,
+                    name = name,
+                    latitude = latitude,
+                    longitude = longitude,
+                    address = address,
+                    kakaoMapPlaceId = kakaoMapPlaceId,
+                    averageRating = averageRating,
+                    reviewCount = reviewCount,
+                )
+            }
+    }
+}

--- a/src/main/kotlin/kr/wooco/woocobe/place/infrastructure/storage/PlaceEntity.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/infrastructure/storage/PlaceEntity.kt
@@ -7,7 +7,6 @@ import jakarta.persistence.Id
 import jakarta.persistence.Table
 import kr.wooco.woocobe.common.storage.BaseTimeEntity
 import kr.wooco.woocobe.place.domain.model.Place
-import kr.wooco.woocobe.user.domain.model.User
 
 @Entity
 @Table(name = "places")
@@ -26,16 +25,13 @@ class PlaceEntity(
     val address: String,
     @Column(name = "name", nullable = false)
     val name: String,
-    @Column(name = "user_id", nullable = false)
-    val userId: Long,
     @Id @Tsid
     @Column(name = "place_id", nullable = false)
     val id: Long? = 0L,
 ) : BaseTimeEntity() {
-    fun toDomain(user: User): Place =
+    fun toDomain(): Place =
         Place(
             id = id!!,
-            user = user,
             name = name,
             latitude = latitude,
             longitude = longitude,
@@ -50,7 +46,6 @@ class PlaceEntity(
             with(place) {
                 PlaceEntity(
                     id = id,
-                    userId = user.id,
                     name = name,
                     latitude = latitude,
                     longitude = longitude,

--- a/src/main/kotlin/kr/wooco/woocobe/place/infrastructure/storage/PlaceJpaRepository.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/infrastructure/storage/PlaceJpaRepository.kt
@@ -1,0 +1,7 @@
+package kr.wooco.woocobe.place.infrastructure.storage
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface PlaceJpaRepository : JpaRepository<PlaceEntity, Long> {
+    fun existsByKakaoMapPlaceId(kakaoMapPlaceId: String): Boolean
+}

--- a/src/main/kotlin/kr/wooco/woocobe/place/infrastructure/storage/PlaceOneLineReviewEntity.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/infrastructure/storage/PlaceOneLineReviewEntity.kt
@@ -1,0 +1,34 @@
+package kr.wooco.woocobe.place.infrastructure.storage
+
+import io.hypersistence.utils.hibernate.id.Tsid
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import kr.wooco.woocobe.common.storage.BaseTimeEntity
+import kr.wooco.woocobe.place.domain.model.PlaceOneLineReview
+
+@Entity
+@Table(name = "place_one_line_reviews")
+class PlaceOneLineReviewEntity(
+    @Column(name = "content")
+    val content: String,
+    @Column(name = "place_id")
+    val placeReviewId: Long,
+    @Id @Tsid
+    @Column(name = "place_one_line_review_id")
+    val id: Long? = 0L,
+) : BaseTimeEntity() {
+    fun toDomain(): PlaceOneLineReview = PlaceOneLineReview(content = content)
+
+    companion object {
+        fun of(
+            placeReviewId: Long,
+            content: String,
+        ): PlaceOneLineReviewEntity =
+            PlaceOneLineReviewEntity(
+                placeReviewId = placeReviewId,
+                content = content,
+            )
+    }
+}

--- a/src/main/kotlin/kr/wooco/woocobe/place/infrastructure/storage/PlaceOneLineReviewJpaRepository.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/infrastructure/storage/PlaceOneLineReviewJpaRepository.kt
@@ -1,0 +1,9 @@
+package kr.wooco.woocobe.place.infrastructure.storage
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface PlaceOneLineReviewJpaRepository : JpaRepository<PlaceOneLineReviewEntity, Long> {
+    fun findAllByPlaceReviewIdOrderByCreatedAt(placeReviewId: Long): List<PlaceOneLineReviewEntity>
+
+    fun findAllByPlaceReviewIdInOrderByCreatedAt(placeReviewId: List<Long>): List<PlaceOneLineReviewEntity>
+}

--- a/src/main/kotlin/kr/wooco/woocobe/place/infrastructure/storage/PlaceReviewEntity.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/infrastructure/storage/PlaceReviewEntity.kt
@@ -40,7 +40,7 @@ class PlaceReviewEntity(
             writeDateTime = createdAt,
             rating = rating,
             content = content,
-            oneLineReview = placeOneLineReview.map { PlaceOneLineReview.from(it.content) },
+            oneLineReviews = placeOneLineReview.map { PlaceOneLineReview.from(it.content) },
             imageUrl = imageUrl,
         )
 

--- a/src/main/kotlin/kr/wooco/woocobe/place/infrastructure/storage/PlaceReviewEntity.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/infrastructure/storage/PlaceReviewEntity.kt
@@ -14,8 +14,6 @@ import kr.wooco.woocobe.user.domain.model.User
 @Entity
 @Table(name = "place_reviews")
 class PlaceReviewEntity(
-    @Column(name = "image_url")
-    val imageUrls: List<String>,
     @Column(name = "content", nullable = false)
     val content: String,
     @Column(name = "rating", nullable = false)
@@ -32,6 +30,7 @@ class PlaceReviewEntity(
         user: User,
         place: Place,
         placeOneLineReview: List<PlaceOneLineReview> = emptyList(),
+        imageUrls: List<String> = emptyList(),
     ): PlaceReview =
         PlaceReview(
             id = id!!,
@@ -51,7 +50,6 @@ class PlaceReviewEntity(
                     id = id,
                     userId = user.id,
                     placeId = place.id,
-                    imageUrls = imageUrls,
                     content = content,
                     rating = rating,
                 )

--- a/src/main/kotlin/kr/wooco/woocobe/place/infrastructure/storage/PlaceReviewEntity.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/infrastructure/storage/PlaceReviewEntity.kt
@@ -15,7 +15,7 @@ import kr.wooco.woocobe.user.domain.model.User
 @Table(name = "place_reviews")
 class PlaceReviewEntity(
     @Column(name = "image_url")
-    val imageUrl: String,
+    val imageUrls: List<String>,
     @Column(name = "content", nullable = false)
     val content: String,
     @Column(name = "rating", nullable = false)
@@ -41,7 +41,7 @@ class PlaceReviewEntity(
             rating = rating,
             content = content,
             oneLineReviews = placeOneLineReview.map { PlaceOneLineReview.from(it.content) },
-            imageUrl = imageUrl,
+            imageUrls = imageUrls,
         )
 
     companion object {
@@ -51,7 +51,7 @@ class PlaceReviewEntity(
                     id = id,
                     userId = user.id,
                     placeId = place.id,
-                    imageUrl = imageUrl,
+                    imageUrls = imageUrls,
                     content = content,
                     rating = rating,
                 )

--- a/src/main/kotlin/kr/wooco/woocobe/place/infrastructure/storage/PlaceReviewEntity.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/infrastructure/storage/PlaceReviewEntity.kt
@@ -1,0 +1,60 @@
+package kr.wooco.woocobe.place.infrastructure.storage
+
+import io.hypersistence.utils.hibernate.id.Tsid
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import kr.wooco.woocobe.common.storage.BaseTimeEntity
+import kr.wooco.woocobe.place.domain.model.Place
+import kr.wooco.woocobe.place.domain.model.PlaceOneLineReview
+import kr.wooco.woocobe.place.domain.model.PlaceReview
+import kr.wooco.woocobe.user.domain.model.User
+
+@Entity
+@Table(name = "place_reviews")
+class PlaceReviewEntity(
+    @Column(name = "image_url")
+    val imageUrl: String,
+    @Column(name = "content", nullable = false)
+    val content: String,
+    @Column(name = "rating", nullable = false)
+    val rating: Double,
+    @Column(name = "user_id", nullable = false)
+    val userId: Long,
+    @Column(name = "place_id", nullable = false)
+    val placeId: Long,
+    @Id @Tsid
+    @Column(name = "place_review_id", nullable = false)
+    val id: Long? = 0L,
+) : BaseTimeEntity() {
+    fun toDomain(
+        user: User,
+        place: Place,
+        placeOneLineReview: List<PlaceOneLineReview> = emptyList(),
+    ): PlaceReview =
+        PlaceReview(
+            id = id!!,
+            user = user,
+            place = place,
+            writeDateTime = createdAt,
+            rating = rating,
+            content = content,
+            oneLineReview = placeOneLineReview.map { PlaceOneLineReview.from(it.content) },
+            imageUrl = imageUrl,
+        )
+
+    companion object {
+        fun from(placeReview: PlaceReview): PlaceReviewEntity =
+            with(placeReview) {
+                PlaceReviewEntity(
+                    id = id,
+                    userId = user.id,
+                    placeId = place.id,
+                    imageUrl = imageUrl,
+                    content = content,
+                    rating = rating,
+                )
+            }
+    }
+}

--- a/src/main/kotlin/kr/wooco/woocobe/place/infrastructure/storage/PlaceReviewImageEntity.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/infrastructure/storage/PlaceReviewImageEntity.kt
@@ -1,0 +1,19 @@
+package kr.wooco.woocobe.place.infrastructure.storage
+
+import io.hypersistence.utils.hibernate.id.Tsid
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "place_review_images")
+class PlaceReviewImageEntity(
+    @Column(name = "image_url")
+    val imageUrl: String,
+    @Column(name = "place_id")
+    val placeReviewId: Long,
+    @Id @Tsid
+    @Column(name = "place_review_images_id")
+    val id: Long? = 0L,
+)

--- a/src/main/kotlin/kr/wooco/woocobe/place/infrastructure/storage/PlaceReviewJpaRepository.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/infrastructure/storage/PlaceReviewJpaRepository.kt
@@ -1,0 +1,11 @@
+package kr.wooco.woocobe.place.infrastructure.storage
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface PlaceReviewJpaRepository : JpaRepository<PlaceReviewEntity, Long> {
+    fun findAllByPlaceIdOrderByCreatedAt(placeId: Long): List<PlaceReviewEntity>
+
+    fun findAllByIdInOrderByCreatedAt(placeReviewIds: List<Long>): List<PlaceReviewEntity>
+
+    fun findAllByUserIdOrderByCreatedAt(userId: Long): List<PlaceReviewEntity>
+}


### PR DESCRIPTION
## 📝 개요

<!-- 이 PR의 목적과 관련된 정보를 간략히 설명합니다. -->
 - 장소와 장소 리뷰를 관리하는 도메인 모델 및 관련 UseCase, StorageGateway를 구현했습니다. 
 
## ✨ 변경 사항

<!-- 코드나 기능의 주요 변경 사항을 설명 -->

- **도메인 모델 추가**
  - `Place`, `PlaceReview`, `PlaceOneLineReview` 도메인 클래스 생성
  - 평균 평점, 리뷰 수 업데이트 로직 포함

- **StorageGateway 인터페이스 및 JPA 구현**
  - `PlaceStorageGateway`와 `PlaceReviewStorageGateway` 생성
  - 관련 JPA 구현 (`JpaPlaceStorageGateway`, `JpaPlaceReviewStorageGateway`)

- **UseCase 구현**
  - 장소 추가: `AddPlaceUseCase`
  - 장소 조회: `GetPlaceUseCase`
  - 리뷰 추가: `AddPlaceReviewUseCase`
  - 리뷰 조회: `GetPlaceReviewUseCase`, `GetAllPlaceReviewUseCase`, `GetUserAllPlaceReviewUseCase`
  - 리뷰 수정: `UpdatePlaceReviewUseCase`
  - 리뷰 삭제: `DeletePlaceReviewUseCase`

- **데이터 저장소 구현**
  - JPA 엔티티 및 레포지토리 추가 (`PlaceEntity`, `PlaceReviewEntity`, `PlaceOneLineReviewEntity`)

## 🔗 관련 이슈

- closed #23

## ℹ️ 참고 사항

<!-- 리뷰어가 알 필요가 있는 추가 정보나 문서, 참고 링크를 포함 (없으면 생략) -->
- 해당 장소에 대한 평균 평점 로직과 한줄평 통계 로직은 아직 고려하고 있습니다. |
- 많이 미숙합니다. 혹독한 피드백 부탁드립니다. 
