### PR TITLE
feat: 카카오맵 장소 ID로 장소 조회 기능 추가

### DIFF
--- a/src/main/kotlin/kr/wooco/woocobe/place/domain/gateway/PlaceStorageGateway.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/domain/gateway/PlaceStorageGateway.kt
@@ -7,5 +7,7 @@ interface PlaceStorageGateway {
 
     fun getByPlaceId(placeId: Long): Place?
 
-    fun existsByKakaoMapPlaceId(placeId: String): Boolean
+    fun existsByKakaoMapPlaceId(kakaoMapPlaceId: String): Boolean
+
+    fun getByKakaoMapPlaceId(kakaoMapPlaceId: String): Place
 }

--- a/src/main/kotlin/kr/wooco/woocobe/place/infrastructure/gateway/JpaPlaceStorageGateway.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/infrastructure/gateway/JpaPlaceStorageGateway.kt
@@ -4,13 +4,11 @@ import kr.wooco.woocobe.place.domain.gateway.PlaceStorageGateway
 import kr.wooco.woocobe.place.domain.model.Place
 import kr.wooco.woocobe.place.infrastructure.storage.PlaceEntity
 import kr.wooco.woocobe.place.infrastructure.storage.PlaceJpaRepository
-import kr.wooco.woocobe.user.infrastructure.storage.UserJpaRepository
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Component
 
 @Component
 class JpaPlaceStorageGateway(
-    private val userJpaRepository: UserJpaRepository,
     private val placeJpaRepository: PlaceJpaRepository,
 ) : PlaceStorageGateway {
     override fun save(place: Place): Place {
@@ -21,5 +19,7 @@ class JpaPlaceStorageGateway(
 
     override fun getByPlaceId(placeId: Long): Place? = placeJpaRepository.findByIdOrNull(placeId)?.toDomain()
 
-    override fun existsByKakaoMapPlaceId(placeId: String): Boolean = placeJpaRepository.existsByKakaoMapPlaceId(placeId)
+    override fun existsByKakaoMapPlaceId(kakaoMapPlaceId: String): Boolean = placeJpaRepository.existsByKakaoMapPlaceId(kakaoMapPlaceId)
+
+    override fun getByKakaoMapPlaceId(kakaoMapPlaceId: String): Place = placeJpaRepository.findByKakaoMapPlaceId(kakaoMapPlaceId).toDomain()
 }

--- a/src/main/kotlin/kr/wooco/woocobe/place/infrastructure/storage/PlaceJpaRepository.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/infrastructure/storage/PlaceJpaRepository.kt
@@ -4,4 +4,6 @@ import org.springframework.data.jpa.repository.JpaRepository
 
 interface PlaceJpaRepository : JpaRepository<PlaceEntity, Long> {
     fun existsByKakaoMapPlaceId(kakaoMapPlaceId: String): Boolean
+
+    fun findByKakaoMapPlaceId(kakaoMapPlaceId: String): PlaceEntity
 }


### PR DESCRIPTION
## 📝 개요
<!-- 이 PR의 목적과 관련된 정보를 간략히 설명합니다. -->
- 카카오맵 ID 를 활용해서 장소 정보를 조회할 수 있는 기능 추가

## ✨ 변경 사항

<!-- 코드나 기능의 주요 변경 사항을 설명 -->

- **`PlaceStorageGateway` 인터페이스 업데이트**
  - `getByKakaoMapPlaceId(kakaoMapPlaceId: String): Place` 메서드 추가.

- **`JpaPlaceStorageGateway` 구현**
  - `getByKakaoMapPlaceId` 메서드 구현

- **`PlaceJpaRepository` 업데이트**
  - `findByKakaoMapPlaceId(kakaoMapPlaceId: String): PlaceEntity` 메서드 추가.


## 🔗 관련 이슈

- closed #47

## ℹ️ 참고 사항

<!-- 리뷰어가 알 필요가 있는 추가 정보나 문서, 참고 링크를 포함 (없으면 생략) -->

