### PR TITLE
feat: 장소 리뷰 도메인 평점 계산 및 한줄평 통계 조회 기능 추가

### DIFF
--- a/src/main/kotlin/kr/wooco/woocobe/place/domain/gateway/PlaceOneLineReviewStorageGateway.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/domain/gateway/PlaceOneLineReviewStorageGateway.kt
@@ -1,0 +1,7 @@
+package kr.wooco.woocobe.place.domain.gateway
+
+import kr.wooco.woocobe.place.domain.model.PlaceOneLineReviewStat
+
+interface PlaceOneLineReviewStorageGateway {
+    fun getOneLineReviewStats(placeId: Long): List<PlaceOneLineReviewStat>
+}

--- a/src/main/kotlin/kr/wooco/woocobe/place/domain/model/Place.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/domain/model/Place.kt
@@ -11,20 +11,29 @@ class Place(
     var reviewCount: Long,
     // 한줄평 통계 로직 고려 중
 ) {
-    fun increaseReviewCount() =
-        apply {
-            reviewCount++
-        }
+    fun addReview(newRating: Double) {
+        averageRating = ((averageRating * reviewCount) + newRating) / (reviewCount + 1)
+        reviewCount++
+    }
 
-    fun decreaseReviewCount() =
-        apply {
+    fun updateReview(
+        oldRating: Double,
+        newRating: Double,
+    ) {
+        if (reviewCount > 0) {
+            averageRating += (newRating - oldRating) / reviewCount
+        }
+    }
+
+    fun deleteReview(oldRating: Double) {
+        if (reviewCount > 1) {
+            averageRating = ((averageRating * reviewCount) - oldRating) / (reviewCount - 1)
             reviewCount--
+        } else {
+            averageRating = 0.0
+            reviewCount = 0
         }
-
-    fun updateAverageRating(rating: Double) =
-        apply {
-            averageRating = (averageRating * reviewCount + rating) / (reviewCount)
-        }
+    }
 
     companion object {
         fun register(

--- a/src/main/kotlin/kr/wooco/woocobe/place/domain/model/PlaceOneLineReviewStat.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/domain/model/PlaceOneLineReviewStat.kt
@@ -1,0 +1,6 @@
+package kr.wooco.woocobe.place.domain.model
+
+class PlaceOneLineReviewStat(
+    val content: String,
+    val count: Long,
+)

--- a/src/main/kotlin/kr/wooco/woocobe/place/domain/usecase/AddPlaceReviewUseCase.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/domain/usecase/AddPlaceReviewUseCase.kt
@@ -37,8 +37,8 @@ class AddPlaceReviewUseCase(
                 oneLineReview = input.oneLineReviews,
                 imageUrls = input.imageUrls,
             ).also(placeReviewStorageGateway::save)
-        place.increaseReviewCount()
 
+        place.addReview(input.rating)
         placeStorageGateway.save(place)
     }
 }

--- a/src/main/kotlin/kr/wooco/woocobe/place/domain/usecase/DeletePlaceReviewUseCase.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/domain/usecase/DeletePlaceReviewUseCase.kt
@@ -27,8 +27,10 @@ class DeletePlaceReviewUseCase(
 
         placeReviewStorageGateway.deleteByPlaceReviewId(placeReviewId = placeReview.id)
 
-        placeReview.place.decreaseReviewCount()
+        val place = placeReview.place
 
-        placeStorageGateway.save(placeReview.place)
+        place.deleteReview(oldRating = placeReview.rating)
+
+        placeStorageGateway.save(place)
     }
 }

--- a/src/main/kotlin/kr/wooco/woocobe/place/domain/usecase/GetOneLineReviewStatsUseCase.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/domain/usecase/GetOneLineReviewStatsUseCase.kt
@@ -1,0 +1,26 @@
+package kr.wooco.woocobe.place.domain.usecase
+
+import kr.wooco.woocobe.common.domain.usecase.UseCase
+import kr.wooco.woocobe.place.domain.gateway.PlaceOneLineReviewStorageGateway
+import kr.wooco.woocobe.place.domain.model.PlaceOneLineReviewStat
+
+data class GetOneLineReviewStatsInput(
+    val placeId: Long,
+)
+
+data class GetOneLineReviewStatsOutput(
+    val placeOneLineReviewRank: List<PlaceOneLineReviewStat>,
+)
+
+class GetOneLineReviewStatsUseCase(
+    private val placeOneLineReviewStorageGateway: PlaceOneLineReviewStorageGateway,
+) : UseCase<GetOneLineReviewStatsInput, GetOneLineReviewStatsOutput> {
+    override fun execute(input: GetOneLineReviewStatsInput): GetOneLineReviewStatsOutput {
+        val placeOneLineReviewRank =
+            placeOneLineReviewStorageGateway.getOneLineReviewStats(input.placeId)
+
+        return GetOneLineReviewStatsOutput(
+            placeOneLineReviewRank = placeOneLineReviewRank,
+        )
+    }
+}

--- a/src/main/kotlin/kr/wooco/woocobe/place/domain/usecase/UpdatePlaceReviewUseCase.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/domain/usecase/UpdatePlaceReviewUseCase.kt
@@ -2,6 +2,7 @@ package kr.wooco.woocobe.place.domain.usecase
 
 import kr.wooco.woocobe.common.domain.usecase.UseCase
 import kr.wooco.woocobe.place.domain.gateway.PlaceReviewStorageGateway
+import kr.wooco.woocobe.place.domain.gateway.PlaceStorageGateway
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -17,6 +18,7 @@ data class UpdatePlaceReviewInput(
 @Service
 class UpdatePlaceReviewUseCase(
     private val placeReviewStorageGateway: PlaceReviewStorageGateway,
+    private val placeStorageGateway: PlaceStorageGateway,
 ) : UseCase<UpdatePlaceReviewInput, Unit> {
     @Transactional
     override fun execute(input: UpdatePlaceReviewInput) {
@@ -34,5 +36,9 @@ class UpdatePlaceReviewUseCase(
                 oneLineReviews = input.oneLineReviews,
                 imageUrls = input.imageUrls,
             ).also(placeReviewStorageGateway::save)
+
+        val place = placeReview.place
+        place.updateReview(oldRating = placeReview.rating, newRating = input.rating)
+        placeStorageGateway.save(place)
     }
 }

--- a/src/main/kotlin/kr/wooco/woocobe/place/infrastructure/gateway/JpaPlaceOneLineReviewStorageGateway.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/infrastructure/gateway/JpaPlaceOneLineReviewStorageGateway.kt
@@ -1,0 +1,24 @@
+package kr.wooco.woocobe.place.infrastructure.gateway
+
+import kr.wooco.woocobe.place.domain.gateway.PlaceOneLineReviewStorageGateway
+import kr.wooco.woocobe.place.domain.model.PlaceOneLineReviewStat
+import kr.wooco.woocobe.place.infrastructure.storage.PlaceOneLineReviewJpaRepository
+import org.springframework.stereotype.Component
+
+@Component
+class JpaPlaceOneLineReviewStorageGateway(
+    private val placeOneLineReviewRepository: PlaceOneLineReviewJpaRepository,
+) : PlaceOneLineReviewStorageGateway {
+    override fun getOneLineReviewStats(placeId: Long): List<PlaceOneLineReviewStat> {
+        val stats = placeOneLineReviewRepository.findPlaceOneLineReviewStatsByPlaceId(placeId)
+        return stats.map { row ->
+            val content = row["content"] ?: throw RuntimeException()
+            val count = row["count"] ?: throw RuntimeException()
+
+            PlaceOneLineReviewStat(
+                content = content.toString(),
+                count = count,
+            )
+        }
+    }
+}

--- a/src/main/kotlin/kr/wooco/woocobe/place/infrastructure/gateway/JpaPlaceReviewStorageGateway.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/infrastructure/gateway/JpaPlaceReviewStorageGateway.kt
@@ -24,6 +24,7 @@ class JpaPlaceReviewStorageGateway(
             placeReview.oneLineReviews
                 .map {
                     PlaceOneLineReviewEntity.of(
+                        placeId = placeReviewEntity.placeId,
                         placeReviewId = placeReviewEntity.id!!,
                         content = it.content,
                     )
@@ -55,7 +56,9 @@ class JpaPlaceReviewStorageGateway(
                 map { placeReviewEntity ->
                     placeReviewEntity.toDomain(
                         user = userEntities.find { placeReviewEntity.userId == it.id }!!.toDomain(),
-                        place = placeEntities.find { placeReviewEntity.placeId == it.id }!!.toDomain(),
+                        place = placeEntities
+                            .find { placeReviewEntity.placeId == it.id }!!
+                            .toDomain(),
                         placeOneLineReview = placeOneLineReviewEntities
                             .filter { placeReviewEntity.id == it.placeReviewId }
                             .map { it.toDomain() },
@@ -74,7 +77,9 @@ class JpaPlaceReviewStorageGateway(
                 map { placeReviewEntity ->
                     placeReviewEntity.toDomain(
                         user = userEntity.find { placeReviewEntity.userId == it.id }!!.toDomain(),
-                        place = placeJpaRepository.findByIdOrNull(placeReviewEntity.placeId)!!.toDomain(),
+                        place = placeJpaRepository
+                            .findByIdOrNull(placeReviewEntity.placeId)!!
+                            .toDomain(),
                         placeOneLineReview = placeOneLineReviewEntity
                             .filter { placeReviewEntity.id == it.placeReviewId }
                             .map { it.toDomain() },
@@ -93,7 +98,9 @@ class JpaPlaceReviewStorageGateway(
                 map { placeReviewEntity ->
                     placeReviewEntity.toDomain(
                         user = userEntity.toDomain(),
-                        place = placeJpaRepository.findByIdOrNull(placeReviewEntity.placeId)!!.toDomain(),
+                        place = placeJpaRepository
+                            .findByIdOrNull(placeReviewEntity.placeId)!!
+                            .toDomain(),
                         placeOneLineReview = placeOneLineReviewEntity
                             .filter { placeReviewEntity.id == it.placeReviewId }
                             .map { it.toDomain() },

--- a/src/main/kotlin/kr/wooco/woocobe/place/infrastructure/storage/PlaceOneLineReviewEntity.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/infrastructure/storage/PlaceOneLineReviewEntity.kt
@@ -13,8 +13,10 @@ import kr.wooco.woocobe.place.domain.model.PlaceOneLineReview
 class PlaceOneLineReviewEntity(
     @Column(name = "content")
     val content: String,
-    @Column(name = "place_id")
+    @Column(name = "place_Review_id")
     val placeReviewId: Long,
+    @Column(name = "place_id")
+    val placeId: Long,
     @Id @Tsid
     @Column(name = "place_one_line_review_id")
     val id: Long? = 0L,
@@ -23,10 +25,12 @@ class PlaceOneLineReviewEntity(
 
     companion object {
         fun of(
+            placeId: Long,
             placeReviewId: Long,
             content: String,
         ): PlaceOneLineReviewEntity =
             PlaceOneLineReviewEntity(
+                placeId = placeId,
                 placeReviewId = placeReviewId,
                 content = content,
             )

--- a/src/main/kotlin/kr/wooco/woocobe/place/infrastructure/storage/PlaceOneLineReviewJpaRepository.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/infrastructure/storage/PlaceOneLineReviewJpaRepository.kt
@@ -2,7 +2,6 @@ package kr.wooco.woocobe.place.infrastructure.storage
 
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
-import org.springframework.data.repository.query.Param
 
 interface PlaceOneLineReviewJpaRepository : JpaRepository<PlaceOneLineReviewEntity, Long> {
     fun findAllByPlaceReviewIdOrderByCreatedAt(placeReviewId: Long): List<PlaceOneLineReviewEntity>
@@ -18,7 +17,5 @@ interface PlaceOneLineReviewJpaRepository : JpaRepository<PlaceOneLineReviewEnti
             order by count desc
         """,
     )
-    fun findPlaceOneLineReviewStatsByPlaceId(
-        @Param("placeId") placeId: Long,
-    ): List<Map<String, Long>>
+    fun findPlaceOneLineReviewStatsByPlaceId(placeId: Long): List<Map<String, Long>>
 }

--- a/src/main/kotlin/kr/wooco/woocobe/place/infrastructure/storage/PlaceOneLineReviewJpaRepository.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/infrastructure/storage/PlaceOneLineReviewJpaRepository.kt
@@ -1,9 +1,24 @@
 package kr.wooco.woocobe.place.infrastructure.storage
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 
 interface PlaceOneLineReviewJpaRepository : JpaRepository<PlaceOneLineReviewEntity, Long> {
     fun findAllByPlaceReviewIdOrderByCreatedAt(placeReviewId: Long): List<PlaceOneLineReviewEntity>
 
     fun findAllByPlaceReviewIdInOrderByCreatedAt(placeReviewId: List<Long>): List<PlaceOneLineReviewEntity>
+
+    @Query(
+        """
+            select r.content as content, count(r.content) as count
+            from PlaceOneLineReviewEntity r
+            where r.placeId = :placeId
+            group by r.content
+            order by count desc
+        """,
+    )
+    fun findPlaceOneLineReviewStatsByPlaceId(
+        @Param("placeId") placeId: Long,
+    ): List<Map<String, Long>>
 }


### PR DESCRIPTION
## 📝 개요

<!-- 이 PR의 목적과 관련된 정보를 간략히 설명합니다. -->

- 리뷰 로직에 **평점 계산 및 평균 평점 갱신 기능**을 추가
- 특정 장소에 대한 **한줄평 통계 조회 기능**을 구현

## ✨ 변경 사항

<!-- 코드나 기능의 주요 변경 사항을 설명 -->

- **평점 계산 로직 업데이트**
  - `Place` 모델의 `addReview`, `updateReview`, `deleteReview` 메서드 추가:
    - 리뷰 추가/수정/삭제 시 평균 평점과 리뷰 수를 자동으로 갱신하도록 구현.

- **한줄평 통계 조회 기능**
  - **도메인**
    - `PlaceOneLineReviewStat` 모델 추가: 한줄평 내용과 해당 리뷰 수를 나타내는 데이터 구조.
    - `PlaceOneLineReviewStorageGateway` 인터페이스 및 `JpaPlaceOneLineReviewStorageGateway` 구현.
  - **UseCase**
    - `GetOneLineReviewStatsUseCase` 추가:
      - 한줄평 통계를 조회하고 반환.
  - **쿼리**
    - `PlaceOneLineReviewJpaRepository`에 JPQL 쿼리 추가:
      - 한줄평 내용과 빈도를 그룹화하여 통계 데이터를 제공.

- **UseCase 수정**
  - `AddPlaceReviewUseCase`: 리뷰 추가 시 평점 계산 로직 반영.
  - `UpdatePlaceReviewUseCase`: 리뷰 수정 시 평점 업데이트 로직 추가.
  - `DeletePlaceReviewUseCase`: 리뷰 삭제 시 평점과 리뷰 수 감소 로직 추가.

- **잘못된 컬럼명 수정**
  - `PlaceOneLineReviewEntity`에서 컬럼명을 `placeId`로 변경하고 관련 로직 업데이트.


## 🔗 관련 이슈

- closed #53


## ℹ️ 참고 사항

<!-- 리뷰어가 알 필요가 있는 추가 정보나 문서, 참고 링크를 포함 (없으면 생략) -->
- 부족한 부분이 있다면 피드백 부탁드립니다.


