### PR TITLE
feat: Place ID 목록으로 Place 조회 기능 추가

### DIFF
--- a/src/main/kotlin/kr/wooco/woocobe/place/domain/gateway/PlaceStorageGateway.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/domain/gateway/PlaceStorageGateway.kt
@@ -10,4 +10,6 @@ interface PlaceStorageGateway {
     fun existsByKakaoMapPlaceId(kakaoMapPlaceId: String): Boolean
 
     fun getByKakaoMapPlaceId(kakaoMapPlaceId: String): Place
+
+    fun getAllByPlaceIds(placeIds: List<Long>): List<Place>
 }

--- a/src/main/kotlin/kr/wooco/woocobe/place/infrastructure/gateway/JpaPlaceStorageGateway.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/infrastructure/gateway/JpaPlaceStorageGateway.kt
@@ -22,4 +22,6 @@ class JpaPlaceStorageGateway(
     override fun existsByKakaoMapPlaceId(kakaoMapPlaceId: String): Boolean = placeJpaRepository.existsByKakaoMapPlaceId(kakaoMapPlaceId)
 
     override fun getByKakaoMapPlaceId(kakaoMapPlaceId: String): Place = placeJpaRepository.findByKakaoMapPlaceId(kakaoMapPlaceId).toDomain()
+
+    override fun getAllByPlaceIds(placeIds: List<Long>): List<Place> = placeJpaRepository.findAllByIdIn(placeIds).map { it.toDomain() }
 }

--- a/src/main/kotlin/kr/wooco/woocobe/place/infrastructure/storage/PlaceJpaRepository.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/infrastructure/storage/PlaceJpaRepository.kt
@@ -6,4 +6,6 @@ interface PlaceJpaRepository : JpaRepository<PlaceEntity, Long> {
     fun existsByKakaoMapPlaceId(kakaoMapPlaceId: String): Boolean
 
     fun findByKakaoMapPlaceId(kakaoMapPlaceId: String): PlaceEntity
+
+    fun findAllByIdIn(placeIds: List<Long>): List<PlaceEntity>
 }


### PR DESCRIPTION
## 📝 개요

<!-- 이 PR의 목적과 관련된 정보를 간략히 설명합니다. -->

- Place ID 목록을 이용하여 여러 장소 정보를 한 번에 조회할 수 있는 기능을 추가.
## ✨ 변경 사항

<!-- 코드나 기능의 주요 변경 사항을 설명 -->

- **`PlaceStorageGateway` 업데이트**
  - `getAllByPlaceIds(placeIds: List<Long>): List<Place>` 메서드 추가.

- **`JpaPlaceStorageGateway` 업데이트**
  - `getAllByPlaceIds` 메서드 구현:
    - `PlaceJpaRepository`의 `findAllByIdIn` 메서드를 호출하여 결과를 도메인 객체로 변환.

- **`PlaceJpaRepository` 업데이트**
  - `findAllByIdIn(placeIds: List<Long>): List<PlaceEntity>` 메서드 추가:
    - Place ID 목록으로 데이터를 조회하는 JPA 메서드 추가.

## 🔗 관련 이슈

- closed #61

## ℹ️ 참고 사항

<!-- 리뷰어가 알 필요가 있는 추가 정보나 문서, 참고 링크를 포함 (없으면 생략) -->
