### PR TITLE
refactor: 코스 인프라 로직 리팩토링 및 도메인 로직 추가

### DIFF
--- a/src/main/kotlin/kr/wooco/woocobe/course/domain/gateway/CourseCommentStorageGateway.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/course/domain/gateway/CourseCommentStorageGateway.kt
@@ -5,7 +5,7 @@ import kr.wooco.woocobe.course.domain.model.CourseComment
 interface CourseCommentStorageGateway {
     fun save(courseComment: CourseComment): CourseComment
 
-    fun getByCommentId(commentId: Long): CourseComment?
+    fun getByCommentId(commentId: Long): CourseComment
 
     fun getAllByCourseId(courseId: Long): List<CourseComment>
 

--- a/src/main/kotlin/kr/wooco/woocobe/course/domain/gateway/CourseStorageGateway.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/course/domain/gateway/CourseStorageGateway.kt
@@ -7,7 +7,7 @@ import kr.wooco.woocobe.course.domain.model.CourseSortCondition
 interface CourseStorageGateway {
     fun save(course: Course): Course
 
-    fun getByCourseId(courseId: Long): Course?
+    fun getByCourseId(courseId: Long): Course
 
     fun getAllByCourseIds(courseIds: List<Long>): List<Course>
 

--- a/src/main/kotlin/kr/wooco/woocobe/course/domain/gateway/CourseStorageGateway.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/course/domain/gateway/CourseStorageGateway.kt
@@ -9,6 +9,8 @@ interface CourseStorageGateway {
 
     fun getByCourseId(courseId: Long): Course?
 
+    fun getAllByCourseIds(courseIds: List<Long>): List<Course>
+
     fun getAllByRegionAndCategoryWithSort(
         region: CourseRegion,
         category: String,

--- a/src/main/kotlin/kr/wooco/woocobe/course/domain/gateway/CourseStorageGateway.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/course/domain/gateway/CourseStorageGateway.kt
@@ -13,7 +13,7 @@ interface CourseStorageGateway {
 
     fun getAllByRegionAndCategoryWithSort(
         region: CourseRegion,
-        category: String,
+        category: String?,
         sort: CourseSortCondition,
     ): List<Course>
 

--- a/src/main/kotlin/kr/wooco/woocobe/course/domain/gateway/InterestCourseStorageGateway.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/course/domain/gateway/InterestCourseStorageGateway.kt
@@ -8,7 +8,7 @@ interface InterestCourseStorageGateway {
     fun getByCourseIdAndUserId(
         courseId: Long,
         userId: Long,
-    ): InterestCourse?
+    ): InterestCourse
 
     fun getAllByUserId(userId: Long): List<InterestCourse>
 

--- a/src/main/kotlin/kr/wooco/woocobe/course/domain/gateway/InterestCourseStorageGateway.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/course/domain/gateway/InterestCourseStorageGateway.kt
@@ -6,8 +6,8 @@ interface InterestCourseStorageGateway {
     fun save(interestCourse: InterestCourse): InterestCourse
 
     fun getByCourseIdAndUserId(
-        userId: Long,
         courseId: Long,
+        userId: Long,
     ): InterestCourse?
 
     fun getAllByUserId(userId: Long): List<InterestCourse>

--- a/src/main/kotlin/kr/wooco/woocobe/course/domain/model/Course.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/course/domain/model/Course.kt
@@ -1,44 +1,38 @@
 package kr.wooco.woocobe.course.domain.model
 
-import kr.wooco.woocobe.user.domain.model.User
 import java.time.LocalDateTime
 
 class Course(
     val id: Long,
-    val user: User,
+    val userId: Long,
     val region: CourseRegion,
-    val writeDateTime: LocalDateTime,
     var categories: List<CourseCategory>,
     var name: String,
     var contents: String,
     var views: Long,
     var comments: Long,
     var interests: Long,
+    val writeDateTime: LocalDateTime,
 ) {
-    fun increaseViews() =
-        apply {
-            views++
-        }
+    fun increaseViews() {
+        views++
+    }
 
-    fun increaseComments() =
-        apply {
-            comments++
-        }
+    fun increaseComments() {
+        comments++
+    }
 
-    fun decreaseComments() =
-        apply {
-            comments--
-        }
+    fun decreaseComments() {
+        comments--
+    }
 
-    fun increaseInterests() =
-        apply {
-            interests++
-        }
+    fun increaseInterests() {
+        interests++
+    }
 
-    fun decreaseInterests() =
-        apply {
-            interests--
-        }
+    fun decreaseInterests() {
+        interests--
+    }
 
     fun update(
         name: String,
@@ -50,15 +44,15 @@ class Course(
         this.contents = contents
     }
 
-    fun isWriter(targetId: Long): Boolean =
-        when (user.id == targetId) {
-            true -> true
-            else -> throw RuntimeException()
+    fun isValidWriter(userId: Long) {
+        if (this.userId != userId) {
+            throw RuntimeException()
         }
+    }
 
     companion object {
         fun register(
-            user: User,
+            userId: Long,
             region: CourseRegion,
             categories: List<String>,
             name: String,
@@ -66,15 +60,15 @@ class Course(
         ): Course =
             Course(
                 id = 0L,
-                user = user,
+                userId = userId,
                 region = region,
                 categories = categories.map { CourseCategory.from(it) },
-                writeDateTime = LocalDateTime.now(),
                 name = name,
                 contents = contents,
                 views = 0L,
                 comments = 0L,
                 interests = 0L,
+                writeDateTime = LocalDateTime.now(),
             )
     }
 }

--- a/src/main/kotlin/kr/wooco/woocobe/course/domain/model/Course.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/course/domain/model/Course.kt
@@ -7,6 +7,7 @@ class Course(
     val userId: Long,
     val region: CourseRegion,
     var categories: List<CourseCategory>,
+    var coursePlaces: List<CoursePlace>,
     var name: String,
     var contents: String,
     var views: Long,
@@ -38,10 +39,12 @@ class Course(
         name: String,
         categories: List<String>,
         contents: String,
+        placeIds: List<Long>,
     ) = apply {
         this.name = name
         this.categories = categories.map { CourseCategory.from(it) }
         this.contents = contents
+        this.coursePlaces = processCoursePlaceOrder(placeIds)
     }
 
     fun isValidWriter(userId: Long) {
@@ -55,6 +58,7 @@ class Course(
             userId: Long,
             region: CourseRegion,
             categories: List<String>,
+            placeIds: List<Long>,
             name: String,
             contents: String,
         ): Course =
@@ -63,6 +67,7 @@ class Course(
                 userId = userId,
                 region = region,
                 categories = categories.map { CourseCategory.from(it) },
+                coursePlaces = processCoursePlaceOrder(placeIds),
                 name = name,
                 contents = contents,
                 views = 0L,
@@ -70,5 +75,13 @@ class Course(
                 interests = 0L,
                 writeDateTime = LocalDateTime.now(),
             )
+
+        private fun processCoursePlaceOrder(placeIds: List<Long>): List<CoursePlace> =
+            placeIds.mapIndexed { index: Int, placeId: Long ->
+                CoursePlace(
+                    order = index,
+                    placeId = placeId,
+                )
+            }
     }
 }

--- a/src/main/kotlin/kr/wooco/woocobe/course/domain/model/CourseCategory.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/course/domain/model/CourseCategory.kt
@@ -10,7 +10,7 @@ enum class CourseCategory {
 
     companion object {
         fun from(viewName: String) =
-            entries.find { it.name == viewName }
+            entries.find { it.name == viewName.uppercase() }
                 ?: throw RuntimeException("not found course category $viewName")
     }
 }

--- a/src/main/kotlin/kr/wooco/woocobe/course/domain/model/CourseComment.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/course/domain/model/CourseComment.kt
@@ -1,11 +1,10 @@
 package kr.wooco.woocobe.course.domain.model
 
-import kr.wooco.woocobe.user.domain.model.User
 import java.time.LocalDateTime
 
 class CourseComment(
     val id: Long,
-    val user: User,
+    val userId: Long,
     val courseId: Long,
     var contents: String,
     val commentDateTime: LocalDateTime,
@@ -15,17 +14,21 @@ class CourseComment(
             this.contents = contents
         }
 
-    fun isCommenter(targetId: Long): Boolean = targetId == user.id
+    fun isValidCommenter(userId: Long) {
+        if (this.userId != userId) {
+            throw RuntimeException()
+        }
+    }
 
     companion object {
         fun register(
-            user: User,
+            userId: Long,
             courseId: Long,
             contents: String,
         ): CourseComment =
             CourseComment(
                 id = 0L,
-                user = user,
+                userId = userId,
                 courseId = courseId,
                 contents = contents,
                 commentDateTime = LocalDateTime.now(),

--- a/src/main/kotlin/kr/wooco/woocobe/course/domain/model/CoursePlace.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/course/domain/model/CoursePlace.kt
@@ -1,0 +1,10 @@
+package kr.wooco.woocobe.course.domain.model
+
+data class CoursePlace(
+    val order: Int,
+    val placeId: Long,
+) {
+    init {
+        require(order in 0..4) { "order must be between 0 and 4" }
+    }
+}

--- a/src/main/kotlin/kr/wooco/woocobe/course/domain/model/InterestCourse.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/course/domain/model/InterestCourse.kt
@@ -3,17 +3,17 @@ package kr.wooco.woocobe.course.domain.model
 class InterestCourse(
     val id: Long,
     val userId: Long,
-    val course: Course,
+    val courseId: Long,
 ) {
     companion object {
         fun register(
             userId: Long,
-            course: Course,
+            courseId: Long,
         ): InterestCourse =
             InterestCourse(
                 id = 0L,
                 userId = userId,
-                course = course,
+                courseId = courseId,
             )
     }
 }

--- a/src/main/kotlin/kr/wooco/woocobe/course/domain/usecase/AddCourseCommentUseCase.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/course/domain/usecase/AddCourseCommentUseCase.kt
@@ -4,7 +4,6 @@ import kr.wooco.woocobe.common.domain.usecase.UseCase
 import kr.wooco.woocobe.course.domain.gateway.CourseCommentStorageGateway
 import kr.wooco.woocobe.course.domain.gateway.CourseStorageGateway
 import kr.wooco.woocobe.course.domain.model.CourseComment
-import kr.wooco.woocobe.user.domain.model.User
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -21,18 +20,20 @@ class AddCourseCommentUseCase(
 ) : UseCase<AddCourseCommentInput, Unit> {
     @Transactional
     override fun execute(input: AddCourseCommentInput) {
-        val user = User.register(userId = input.userId)
+        val courseComment = CourseComment.register(
+            userId = input.userId,
+            courseId = input.courseId,
+            contents = input.contents,
+        )
+        courseCommentStorageGateway.save(courseComment)
 
-        CourseComment
-            .register(
-                user = user,
-                courseId = input.courseId,
-                contents = input.contents,
-            ).also(courseCommentStorageGateway::save)
-
-        courseStorageGateway
-            .getByCourseId(courseId = input.courseId)
-            ?.run { increaseComments().also(courseStorageGateway::save) }
+        // TODO
+        // courseStorageGateway.increaseCommentsCounts(courseId = input.courseId)
+        // 또는
+        // 이벤트로 처리해버리기 :: 이벤트 처리전에 courseComment 전용 패키지를 하나 만들어야할듯
+        val course = courseStorageGateway.getByCourseId(input.courseId)
             ?: throw RuntimeException()
+        course.increaseComments()
+        courseStorageGateway.save(course)
     }
 }

--- a/src/main/kotlin/kr/wooco/woocobe/course/domain/usecase/AddCourseCommentUseCase.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/course/domain/usecase/AddCourseCommentUseCase.kt
@@ -32,7 +32,6 @@ class AddCourseCommentUseCase(
         // 또는
         // 이벤트로 처리해버리기 :: 이벤트 처리전에 courseComment 전용 패키지를 하나 만들어야할듯
         val course = courseStorageGateway.getByCourseId(input.courseId)
-            ?: throw RuntimeException()
         course.increaseComments()
         courseStorageGateway.save(course)
     }

--- a/src/main/kotlin/kr/wooco/woocobe/course/domain/usecase/AddCourseUseCase.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/course/domain/usecase/AddCourseUseCase.kt
@@ -4,7 +4,6 @@ import kr.wooco.woocobe.common.domain.usecase.UseCase
 import kr.wooco.woocobe.course.domain.gateway.CourseStorageGateway
 import kr.wooco.woocobe.course.domain.model.Course
 import kr.wooco.woocobe.course.domain.model.CourseRegion
-import kr.wooco.woocobe.user.domain.model.User
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -23,20 +22,15 @@ class AddCourseUseCase(
 ) : UseCase<AddCourseUseCaseInput, Unit> {
     @Transactional
     override fun execute(input: AddCourseUseCaseInput) {
-        val user = User.register(userId = input.userId)
+        val courseRegion = CourseRegion.register(input.primaryRegion, input.secondaryRegion)
 
-        val courseRegion = CourseRegion.register(
-            primaryRegion = input.primaryRegion,
-            secondaryRegion = input.secondaryRegion,
+        val course = Course.register(
+            userId = input.userId,
+            region = courseRegion,
+            categories = input.category,
+            name = input.name,
+            contents = input.contents,
         )
-
-        Course
-            .register(
-                user = user,
-                region = courseRegion,
-                categories = input.category,
-                name = input.name,
-                contents = input.contents,
-            ).also(courseStorageGateway::save)
+        courseStorageGateway.save(course)
     }
 }

--- a/src/main/kotlin/kr/wooco/woocobe/course/domain/usecase/AddCourseUseCase.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/course/domain/usecase/AddCourseUseCase.kt
@@ -14,6 +14,7 @@ data class AddCourseUseCaseInput(
     val category: List<String>,
     val name: String,
     val contents: String,
+    val placeIds: List<Long>,
 )
 
 @Service
@@ -30,6 +31,7 @@ class AddCourseUseCase(
             categories = input.category,
             name = input.name,
             contents = input.contents,
+            placeIds = input.placeIds,
         )
         courseStorageGateway.save(course)
     }

--- a/src/main/kotlin/kr/wooco/woocobe/course/domain/usecase/AddInterestCourseUseCase.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/course/domain/usecase/AddInterestCourseUseCase.kt
@@ -19,20 +19,17 @@ class AddInterestCourseUseCase(
 ) : UseCase<AddInterestCourseInput, Unit> {
     @Transactional
     override fun execute(input: AddInterestCourseInput) {
-        interestCourseStorageGateway
-            .existsByCourseIdAndUserId(courseId = input.courseId, userId = input.userId)
-            .takeIf { it }
-            ?.let { throw RuntimeException() }
+        if (interestCourseStorageGateway.existsByCourseIdAndUserId(courseId = input.courseId, userId = input.userId)) {
+            throw RuntimeException("already interest course ${input.courseId}")
+        }
 
+        val interestCourse = InterestCourse.register(userId = input.userId, courseId = input.courseId)
+        interestCourseStorageGateway.save(interestCourse)
+
+        // TODO: 증가 로직 수정
         val course = courseStorageGateway.getByCourseId(input.courseId)
             ?: throw RuntimeException()
-
-        InterestCourse
-            .register(userId = input.userId, course = course)
-            .also(interestCourseStorageGateway::save)
-
-        course
-            .increaseInterests()
-            .also(courseStorageGateway::save)
+        course.increaseInterests()
+        courseStorageGateway.save(course)
     }
 }

--- a/src/main/kotlin/kr/wooco/woocobe/course/domain/usecase/AddInterestCourseUseCase.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/course/domain/usecase/AddInterestCourseUseCase.kt
@@ -28,7 +28,6 @@ class AddInterestCourseUseCase(
 
         // TODO: 증가 로직 수정
         val course = courseStorageGateway.getByCourseId(input.courseId)
-            ?: throw RuntimeException()
         course.increaseInterests()
         courseStorageGateway.save(course)
     }

--- a/src/main/kotlin/kr/wooco/woocobe/course/domain/usecase/DeleteCourseCommentUseCase.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/course/domain/usecase/DeleteCourseCommentUseCase.kt
@@ -19,8 +19,6 @@ class DeleteCourseCommentUseCase(
     @Transactional
     override fun execute(input: DeleteCourseCommentInput) {
         val courseComment = courseCommentStorageGateway.getByCommentId(input.commentId)
-            ?: throw RuntimeException()
-
         courseComment.isValidCommenter(input.userId)
 
         courseCommentStorageGateway.deleteByCommentId(commentId = courseComment.id)

--- a/src/main/kotlin/kr/wooco/woocobe/course/domain/usecase/DeleteCourseCommentUseCase.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/course/domain/usecase/DeleteCourseCommentUseCase.kt
@@ -26,7 +26,6 @@ class DeleteCourseCommentUseCase(
         courseCommentStorageGateway.deleteByCommentId(commentId = courseComment.id)
 
         val course = courseStorageGateway.getByCourseId(courseComment.courseId)
-            ?: throw RuntimeException()
         course.decreaseComments()
         courseStorageGateway.save(course)
     }

--- a/src/main/kotlin/kr/wooco/woocobe/course/domain/usecase/DeleteCourseUseCase.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/course/domain/usecase/DeleteCourseUseCase.kt
@@ -17,7 +17,6 @@ class DeleteCourseUseCase(
     @Transactional
     override fun execute(input: DeleteCourseInput) {
         val course = courseStorageGateway.getByCourseId(courseId = input.courseId)
-            ?: throw RuntimeException()
         course.isValidWriter(input.userId)
 
         courseStorageGateway.deleteByCourseId(courseId = course.id)

--- a/src/main/kotlin/kr/wooco/woocobe/course/domain/usecase/DeleteCourseUseCase.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/course/domain/usecase/DeleteCourseUseCase.kt
@@ -16,13 +16,9 @@ class DeleteCourseUseCase(
 ) : UseCase<DeleteCourseInput, Unit> {
     @Transactional
     override fun execute(input: DeleteCourseInput) {
-        val course = courseStorageGateway
-            .getByCourseId(courseId = input.courseId)
+        val course = courseStorageGateway.getByCourseId(courseId = input.courseId)
             ?: throw RuntimeException()
-
-        when {
-            course.isWriter(input.userId).not() -> throw RuntimeException()
-        }
+        course.isValidWriter(input.userId)
 
         courseStorageGateway.deleteByCourseId(courseId = course.id)
     }

--- a/src/main/kotlin/kr/wooco/woocobe/course/domain/usecase/DeleteInterestCourseUseCase.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/course/domain/usecase/DeleteInterestCourseUseCase.kt
@@ -18,9 +18,12 @@ class DeleteInterestCourseUseCase(
 ) : UseCase<DeleteInterestCourseInput, Unit> {
     @Transactional
     override fun execute(input: DeleteInterestCourseInput) {
-        interestCourseStorageGateway.getByCourseIdAndUserId(input.userId, input.courseId)?.run {
-            interestCourseStorageGateway.deleteByInterestCourseId(id)
-            course.decreaseInterests().also(courseStorageGateway::save)
-        } ?: throw RuntimeException()
+        val interestCourse = interestCourseStorageGateway.getByCourseIdAndUserId(input.courseId, input.userId)
+            ?: throw RuntimeException()
+
+        val course = courseStorageGateway.getByCourseId(interestCourse.courseId)
+            ?: throw RuntimeException()
+        course.decreaseInterests()
+        courseStorageGateway.save(course)
     }
 }

--- a/src/main/kotlin/kr/wooco/woocobe/course/domain/usecase/DeleteInterestCourseUseCase.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/course/domain/usecase/DeleteInterestCourseUseCase.kt
@@ -19,7 +19,6 @@ class DeleteInterestCourseUseCase(
     @Transactional
     override fun execute(input: DeleteInterestCourseInput) {
         val interestCourse = interestCourseStorageGateway.getByCourseIdAndUserId(input.courseId, input.userId)
-            ?: throw RuntimeException()
 
         val course = courseStorageGateway.getByCourseId(interestCourse.courseId)
         course.decreaseInterests()

--- a/src/main/kotlin/kr/wooco/woocobe/course/domain/usecase/DeleteInterestCourseUseCase.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/course/domain/usecase/DeleteInterestCourseUseCase.kt
@@ -22,7 +22,6 @@ class DeleteInterestCourseUseCase(
             ?: throw RuntimeException()
 
         val course = courseStorageGateway.getByCourseId(interestCourse.courseId)
-            ?: throw RuntimeException()
         course.decreaseInterests()
         courseStorageGateway.save(course)
     }

--- a/src/main/kotlin/kr/wooco/woocobe/course/domain/usecase/GetAllCourseCommentUseCase.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/course/domain/usecase/GetAllCourseCommentUseCase.kt
@@ -19,6 +19,7 @@ class GetAllCourseCommentUseCase(
 ) : UseCase<GetAllCourseCommentInput, GetAllCourseCommentOutput> {
     override fun execute(input: GetAllCourseCommentInput): GetAllCourseCommentOutput {
         val courseComments = courseCommentStorageGateway.getAllByCourseId(input.courseId)
+
         return GetAllCourseCommentOutput(
             courseComments = courseComments,
         )

--- a/src/main/kotlin/kr/wooco/woocobe/course/domain/usecase/GetAllCourseUseCase.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/course/domain/usecase/GetAllCourseUseCase.kt
@@ -23,8 +23,8 @@ class GetAllCourseUseCase(
     private val courseStorageGateway: CourseStorageGateway,
 ) : UseCase<GetAllCourseInput, GetAllCourseOutput> {
     override fun execute(input: GetAllCourseInput): GetAllCourseOutput {
-        val sort = CourseSortCondition.from(value = input.sort)
-        val region = CourseRegion.register(primaryRegion = input.primaryRegion, secondaryRegion = input.secondaryRegion)
+        val sort = CourseSortCondition.from(input.sort)
+        val region = CourseRegion.register(input.primaryRegion, input.secondaryRegion)
 
         val courses = courseStorageGateway.getAllByRegionAndCategoryWithSort(
             region = region,

--- a/src/main/kotlin/kr/wooco/woocobe/course/domain/usecase/GetAllCourseUseCase.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/course/domain/usecase/GetAllCourseUseCase.kt
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Service
 data class GetAllCourseInput(
     val primaryRegion: String,
     val secondaryRegion: String,
-    val category: String,
+    val category: String?,
     val sort: String,
 )
 

--- a/src/main/kotlin/kr/wooco/woocobe/course/domain/usecase/GetAllMyCourseUseCase.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/course/domain/usecase/GetAllMyCourseUseCase.kt
@@ -6,23 +6,23 @@ import kr.wooco.woocobe.course.domain.model.Course
 import kr.wooco.woocobe.course.domain.model.CourseSortCondition
 import org.springframework.stereotype.Service
 
-data class GetUserAllCourseInput(
+data class GetAllByCourseInput(
     val userId: Long,
     val sort: CourseSortCondition,
 )
 
-data class GetUserAllCourseOutput(
+data class GetAllMyCourseOutput(
     val courses: List<Course>,
 )
 
 @Service
-class GetUserAllCourseUseCase(
+class GetAllMyCourseUseCase(
     private val courseStorageGateway: CourseStorageGateway,
-) : UseCase<GetUserAllCourseInput, GetUserAllCourseOutput> {
-    override fun execute(input: GetUserAllCourseInput): GetUserAllCourseOutput {
+) : UseCase<GetAllByCourseInput, GetAllMyCourseOutput> {
+    override fun execute(input: GetAllByCourseInput): GetAllMyCourseOutput {
         val courses = courseStorageGateway.getAllByUserIdWithSort(input.userId, input.sort)
 
-        return GetUserAllCourseOutput(
+        return GetAllMyCourseOutput(
             courses = courses,
         )
     }

--- a/src/main/kotlin/kr/wooco/woocobe/course/domain/usecase/GetAllMyInterestCourseUseCase.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/course/domain/usecase/GetAllMyInterestCourseUseCase.kt
@@ -1,6 +1,7 @@
 package kr.wooco.woocobe.course.domain.usecase
 
 import kr.wooco.woocobe.common.domain.usecase.UseCase
+import kr.wooco.woocobe.course.domain.gateway.CourseStorageGateway
 import kr.wooco.woocobe.course.domain.gateway.InterestCourseStorageGateway
 import kr.wooco.woocobe.course.domain.model.Course
 import org.springframework.stereotype.Service
@@ -16,14 +17,17 @@ data class GetAllMyInterestCourseOutput(
 
 @Service
 class GetAllMyInterestCourseUseCase(
+    private val courseStorageGateway: CourseStorageGateway,
     private val interestCourseStorageGateway: InterestCourseStorageGateway,
 ) : UseCase<GetAllMyInterestCourseInput, GetAllMyInterestCourseOutput> {
     @Transactional(readOnly = true)
     override fun execute(input: GetAllMyInterestCourseInput): GetAllMyInterestCourseOutput {
         val interestCourses = interestCourseStorageGateway.getAllByUserId(userId = input.userId)
+        val courseIds = interestCourses.map { it.courseId }
+        val courses = courseStorageGateway.getAllByCourseIds(courseIds)
 
         return GetAllMyInterestCourseOutput(
-            courses = interestCourses.map { it.course },
+            courses = courses,
         )
     }
 }

--- a/src/main/kotlin/kr/wooco/woocobe/course/domain/usecase/GetCourseUseCase.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/course/domain/usecase/GetCourseUseCase.kt
@@ -25,11 +25,13 @@ class GetCourseUseCase(
         val course = courseStorageGateway.getByCourseId(input.courseId)
             ?: throw RuntimeException()
 
-        val isInterested = input.userId?.let {
+        val isInterested = input.userId?.run {
             interestCourseStorageGateway.existsByCourseIdAndUserId(input.courseId, input.userId)
         } ?: false
 
-        course.increaseViews().also(courseStorageGateway::save)
+        // TODO 이벤트 기반 고려 :: Query 작업에 Command 작업이 껴있다.
+        course.increaseViews()
+        courseStorageGateway.save(course)
 
         return GetCourseOutput(
             course = course,

--- a/src/main/kotlin/kr/wooco/woocobe/course/domain/usecase/GetCourseUseCase.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/course/domain/usecase/GetCourseUseCase.kt
@@ -23,7 +23,6 @@ class GetCourseUseCase(
 ) : UseCase<GetCourseInput, GetCourseOutput> {
     override fun execute(input: GetCourseInput): GetCourseOutput {
         val course = courseStorageGateway.getByCourseId(input.courseId)
-            ?: throw RuntimeException()
 
         val isInterested = input.userId?.run {
             interestCourseStorageGateway.existsByCourseIdAndUserId(input.courseId, input.userId)

--- a/src/main/kotlin/kr/wooco/woocobe/course/domain/usecase/UpdateCourseCommentUseCase.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/course/domain/usecase/UpdateCourseCommentUseCase.kt
@@ -19,13 +19,9 @@ class UpdateCourseCommentUseCase(
     override fun execute(input: UpdateCourseCommentInput) {
         val courseComment = courseCommentStorageGateway.getByCommentId(input.commentId)
             ?: throw RuntimeException()
+        courseComment.isValidCommenter(input.userId)
 
-        when {
-            courseComment.isCommenter(input.userId).not() -> throw RuntimeException()
-        }
-
-        courseComment
-            .update(contents = input.contents)
-            .also(courseCommentStorageGateway::save)
+        courseComment.update(contents = input.contents)
+        courseCommentStorageGateway.save(courseComment)
     }
 }

--- a/src/main/kotlin/kr/wooco/woocobe/course/domain/usecase/UpdateCourseCommentUseCase.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/course/domain/usecase/UpdateCourseCommentUseCase.kt
@@ -18,7 +18,6 @@ class UpdateCourseCommentUseCase(
     @Transactional
     override fun execute(input: UpdateCourseCommentInput) {
         val courseComment = courseCommentStorageGateway.getByCommentId(input.commentId)
-            ?: throw RuntimeException()
         courseComment.isValidCommenter(input.userId)
 
         courseComment.update(contents = input.contents)

--- a/src/main/kotlin/kr/wooco/woocobe/course/domain/usecase/UpdateCourseUseCase.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/course/domain/usecase/UpdateCourseUseCase.kt
@@ -20,7 +20,6 @@ class UpdateCourseUseCase(
     @Transactional
     override fun execute(input: UpdateCourseInput) {
         val course = courseStorageGateway.getByCourseId(courseId = input.courseId)
-            ?: throw RuntimeException()
         course.isValidWriter(input.userId)
 
         course.update(

--- a/src/main/kotlin/kr/wooco/woocobe/course/domain/usecase/UpdateCourseUseCase.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/course/domain/usecase/UpdateCourseUseCase.kt
@@ -11,6 +11,7 @@ data class UpdateCourseInput(
     val name: String,
     val contents: String,
     val categories: List<String>,
+    val placeIds: List<Long>,
 )
 
 @Service
@@ -26,6 +27,7 @@ class UpdateCourseUseCase(
             name = input.name,
             contents = input.contents,
             categories = input.categories,
+            placeIds = input.placeIds,
         )
         courseStorageGateway.save(course)
     }

--- a/src/main/kotlin/kr/wooco/woocobe/course/domain/usecase/UpdateCourseUseCase.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/course/domain/usecase/UpdateCourseUseCase.kt
@@ -21,16 +21,13 @@ class UpdateCourseUseCase(
     override fun execute(input: UpdateCourseInput) {
         val course = courseStorageGateway.getByCourseId(courseId = input.courseId)
             ?: throw RuntimeException()
+        course.isValidWriter(input.userId)
 
-        when {
-            course.isWriter(input.userId).not() -> throw RuntimeException()
-        }
-
-        course
-            .update(
-                name = input.name,
-                contents = input.contents,
-                categories = input.categories,
-            ).also(courseStorageGateway::save)
+        course.update(
+            name = input.name,
+            contents = input.contents,
+            categories = input.categories,
+        )
+        courseStorageGateway.save(course)
     }
 }

--- a/src/main/kotlin/kr/wooco/woocobe/course/infrastructure/gateway/CourseCommentStorageGatewayImpl.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/course/infrastructure/gateway/CourseCommentStorageGatewayImpl.kt
@@ -8,7 +8,7 @@ import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Component
 
 @Component
-class CourseCommentStorageGatewayImpl(
+internal class CourseCommentStorageGatewayImpl(
     private val courseCommentJpaRepository: CourseCommentJpaRepository,
 ) : CourseCommentStorageGateway {
     override fun save(courseComment: CourseComment): CourseComment =

--- a/src/main/kotlin/kr/wooco/woocobe/course/infrastructure/gateway/CourseCommentStorageGatewayImpl.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/course/infrastructure/gateway/CourseCommentStorageGatewayImpl.kt
@@ -2,17 +2,17 @@ package kr.wooco.woocobe.course.infrastructure.gateway
 
 import kr.wooco.woocobe.course.domain.gateway.CourseCommentStorageGateway
 import kr.wooco.woocobe.course.domain.model.CourseComment
-import kr.wooco.woocobe.course.infrastructure.storage.entity.CourseCommentEntity
+import kr.wooco.woocobe.course.infrastructure.storage.entity.CourseCommentJpaEntity
 import kr.wooco.woocobe.course.infrastructure.storage.repository.CourseCommentJpaRepository
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Component
 
 @Component
-class JpaCourseCommentStorageGateway(
+class CourseCommentStorageGatewayImpl(
     private val courseCommentJpaRepository: CourseCommentJpaRepository,
 ) : CourseCommentStorageGateway {
     override fun save(courseComment: CourseComment): CourseComment =
-        courseCommentJpaRepository.save(CourseCommentEntity.from(courseComment)).toDomain()
+        courseCommentJpaRepository.save(CourseCommentJpaEntity.from(courseComment)).toDomain()
 
     override fun getByCommentId(commentId: Long): CourseComment? = courseCommentJpaRepository.findByIdOrNull(commentId)?.toDomain()
 

--- a/src/main/kotlin/kr/wooco/woocobe/course/infrastructure/gateway/CourseCommentStorageGatewayImpl.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/course/infrastructure/gateway/CourseCommentStorageGatewayImpl.kt
@@ -2,7 +2,7 @@ package kr.wooco.woocobe.course.infrastructure.gateway
 
 import kr.wooco.woocobe.course.domain.gateway.CourseCommentStorageGateway
 import kr.wooco.woocobe.course.domain.model.CourseComment
-import kr.wooco.woocobe.course.infrastructure.storage.entity.CourseCommentJpaEntity
+import kr.wooco.woocobe.course.infrastructure.storage.CourseCommentStorageMapper
 import kr.wooco.woocobe.course.infrastructure.storage.repository.CourseCommentJpaRepository
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Component
@@ -10,14 +10,24 @@ import org.springframework.stereotype.Component
 @Component
 internal class CourseCommentStorageGatewayImpl(
     private val courseCommentJpaRepository: CourseCommentJpaRepository,
+    private val courseCommentStorageMapper: CourseCommentStorageMapper,
 ) : CourseCommentStorageGateway {
-    override fun save(courseComment: CourseComment): CourseComment =
-        courseCommentJpaRepository.save(CourseCommentJpaEntity.from(courseComment)).toDomain()
+    override fun save(courseComment: CourseComment): CourseComment {
+        val courseCommentEntity = courseCommentStorageMapper.toEntity(courseComment)
+        courseCommentJpaRepository.save(courseCommentEntity)
+        return courseCommentStorageMapper.toDomain(courseCommentEntity)
+    }
 
-    override fun getByCommentId(commentId: Long): CourseComment? = courseCommentJpaRepository.findByIdOrNull(commentId)?.toDomain()
+    override fun getByCommentId(commentId: Long): CourseComment {
+        val courseCommentEntity = courseCommentJpaRepository.findByIdOrNull(commentId)
+            ?: throw RuntimeException()
+        return courseCommentStorageMapper.toDomain(courseCommentEntity)
+    }
 
-    override fun getAllByCourseId(courseId: Long): List<CourseComment> =
-        courseCommentJpaRepository.findAllByCourseId(courseId).map { it.toDomain() }
+    override fun getAllByCourseId(courseId: Long): List<CourseComment> {
+        val courseCommentEntities = courseCommentJpaRepository.findAllByCourseId(courseId)
+        return courseCommentEntities.map { courseCommentStorageMapper.toDomain(it) }
+    }
 
     override fun deleteByCommentId(commentId: Long) = courseCommentJpaRepository.deleteById(commentId)
 }

--- a/src/main/kotlin/kr/wooco/woocobe/course/infrastructure/gateway/CourseStorageGatewayImpl.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/course/infrastructure/gateway/CourseStorageGatewayImpl.kt
@@ -62,7 +62,7 @@ internal class CourseStorageGatewayImpl(
 
     override fun getAllByRegionAndCategoryWithSort(
         region: CourseRegion,
-        category: String,
+        category: String?,
         sort: CourseSortCondition,
     ): List<Course> {
         val courseEntities =

--- a/src/main/kotlin/kr/wooco/woocobe/course/infrastructure/gateway/CourseStorageGatewayImpl.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/course/infrastructure/gateway/CourseStorageGatewayImpl.kt
@@ -15,7 +15,7 @@ import org.springframework.stereotype.Component
 
 @Component
 @Suppress("Duplicates")
-class CourseStorageGatewayImpl(
+internal class CourseStorageGatewayImpl(
     private val courseJpaRepository: CourseJpaRepository,
     private val coursePlaceJpaRepository: CoursePlaceJpaRepository,
     private val courseCategoryJpaRepository: CourseCategoryJpaRepository,

--- a/src/main/kotlin/kr/wooco/woocobe/course/infrastructure/gateway/CourseStorageGatewayImpl.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/course/infrastructure/gateway/CourseStorageGatewayImpl.kt
@@ -5,42 +5,56 @@ import kr.wooco.woocobe.course.domain.model.Course
 import kr.wooco.woocobe.course.domain.model.CourseRegion
 import kr.wooco.woocobe.course.domain.model.CourseSortCondition
 import kr.wooco.woocobe.course.infrastructure.storage.CourseCategoryStorageMapper
+import kr.wooco.woocobe.course.infrastructure.storage.CoursePlaceStorageMapper
 import kr.wooco.woocobe.course.infrastructure.storage.CourseStorageMapper
 import kr.wooco.woocobe.course.infrastructure.storage.repository.CourseCategoryJpaRepository
 import kr.wooco.woocobe.course.infrastructure.storage.repository.CourseJpaRepository
+import kr.wooco.woocobe.course.infrastructure.storage.repository.CoursePlaceJpaRepository
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Component
 
 @Component
+@Suppress("Duplicates")
 class CourseStorageGatewayImpl(
     private val courseJpaRepository: CourseJpaRepository,
+    private val coursePlaceJpaRepository: CoursePlaceJpaRepository,
     private val courseCategoryJpaRepository: CourseCategoryJpaRepository,
     private val courseStorageMapper: CourseStorageMapper,
+    private val coursePlaceStorageMapper: CoursePlaceStorageMapper,
     private val courseCategoryStorageMapper: CourseCategoryStorageMapper,
 ) : CourseStorageGateway {
-    // FIXME: 업데이트 로직 분리
+    // FIXME: 업데이트 로직 분리 (저장할 때마다 카테고리들과 코스 장소를 전부 삭제했다가 다시 저장함)
     override fun save(course: Course): Course {
         val courseEntity = courseStorageMapper.toEntity(course)
         courseJpaRepository.save(courseEntity)
+
+        coursePlaceJpaRepository.deleteAllByCourseId(courseEntity.id!!)
+        val coursePlaceEntities = course.coursePlaces.map { coursePlaceStorageMapper.toEntity(courseEntity, it) }
+        coursePlaceJpaRepository.saveAll(coursePlaceEntities)
+
         courseCategoryJpaRepository.deleteAllByCourseId(courseEntity.id!!)
         val courseCategoryEntities = course.categories.map { courseCategoryStorageMapper.toEntity(courseEntity, it) }
         courseCategoryJpaRepository.saveAll(courseCategoryEntities)
-        return courseStorageMapper.toDomain(courseEntity, courseCategoryEntities)
+
+        return courseStorageMapper.toDomain(courseEntity, coursePlaceEntities, courseCategoryEntities)
     }
 
     override fun getByCourseId(courseId: Long): Course {
         val courseEntity = courseJpaRepository.findByIdOrNull(courseId)
             ?: throw RuntimeException()
         val courseCategoryEntities = courseCategoryJpaRepository.findAllByCourseId(courseEntity.id!!)
-        return courseStorageMapper.toDomain(courseEntity, courseCategoryEntities)
+        val coursePlaceEntities = coursePlaceJpaRepository.findAllByCourseId(courseId)
+        return courseStorageMapper.toDomain(courseEntity, coursePlaceEntities, courseCategoryEntities)
     }
 
     override fun getAllByCourseIds(courseIds: List<Long>): List<Course> {
         val courseEntities = courseJpaRepository.findAllById(courseIds)
+        val coursePlaceEntities = coursePlaceJpaRepository.findAllByCourseIdIn(courseIds)
         val courseCategoryEntities = courseCategoryJpaRepository.findAllByCourseIdIn(courseIds)
         return courseEntities.map { courseJpaEntity ->
             courseStorageMapper.toDomain(
                 courseJpaEntity = courseJpaEntity,
+                coursePlaceJpaEntities = coursePlaceEntities.filter { it.courseId == courseJpaEntity.id },
                 courseCategoryJpaEntities = courseCategoryEntities.filter { it.courseId == courseJpaEntity.id },
             )
         }
@@ -53,10 +67,13 @@ class CourseStorageGatewayImpl(
     ): List<Course> {
         val courseEntities =
             courseJpaRepository.findAllByRegionAndCategoryWithSort(region = region, category = category, sort = sort)
+        val courseIds = courseEntities.map { it.id!! }
+        val coursePlaceEntities = coursePlaceJpaRepository.findAllByCourseIdIn(courseIds)
         val courseCategoryEntities = courseCategoryJpaRepository.findAllByCourseIdIn(courseEntities.map { it.id!! })
         return courseEntities.map { courseJpaEntity ->
             courseStorageMapper.toDomain(
                 courseJpaEntity = courseJpaEntity,
+                coursePlaceJpaEntities = coursePlaceEntities.filter { it.courseId == courseJpaEntity.id },
                 courseCategoryJpaEntities = courseCategoryEntities.filter { it.courseId == courseJpaEntity.id },
             )
         }
@@ -67,17 +84,21 @@ class CourseStorageGatewayImpl(
         sort: CourseSortCondition,
     ): List<Course> {
         val courseEntities = courseJpaRepository.findAllByUserIdWithSort(userId = userId, sort = sort)
+        val courseIds = courseEntities.map { it.id!! }
+        val coursePlaceEntities = coursePlaceJpaRepository.findAllByCourseIdIn(courseIds)
         val courseCategoryEntities = courseCategoryJpaRepository.findAllByCourseIdIn(courseEntities.map { it.id!! })
         return courseEntities.map { courseJpaEntity ->
             courseStorageMapper.toDomain(
                 courseJpaEntity = courseJpaEntity,
                 courseCategoryJpaEntities = courseCategoryEntities.filter { it.courseId == courseJpaEntity.id },
+                coursePlaceJpaEntities = coursePlaceEntities.filter { it.courseId == courseJpaEntity.id },
             )
         }
     }
 
     override fun deleteByCourseId(courseId: Long) {
         courseJpaRepository.deleteById(courseId)
+        coursePlaceJpaRepository.deleteAllByCourseId(courseId)
         courseCategoryJpaRepository.deleteAllByCourseId(courseId)
     }
 }

--- a/src/main/kotlin/kr/wooco/woocobe/course/infrastructure/gateway/CourseStorageGatewayImpl.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/course/infrastructure/gateway/CourseStorageGatewayImpl.kt
@@ -4,24 +4,24 @@ import kr.wooco.woocobe.course.domain.gateway.CourseStorageGateway
 import kr.wooco.woocobe.course.domain.model.Course
 import kr.wooco.woocobe.course.domain.model.CourseRegion
 import kr.wooco.woocobe.course.domain.model.CourseSortCondition
-import kr.wooco.woocobe.course.infrastructure.storage.entity.CourseCategoryEntity
-import kr.wooco.woocobe.course.infrastructure.storage.entity.CourseEntity
+import kr.wooco.woocobe.course.infrastructure.storage.entity.CourseCategoryJpaEntity
+import kr.wooco.woocobe.course.infrastructure.storage.entity.CourseJpaEntity
 import kr.wooco.woocobe.course.infrastructure.storage.repository.CourseCategoryJpaRepository
 import kr.wooco.woocobe.course.infrastructure.storage.repository.CourseJpaRepository
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Component
 
 @Component
-class JpaCourseStorageGateway(
+class CourseStorageGatewayImpl(
     private val courseJpaRepository: CourseJpaRepository,
     private val courseCategoryJpaRepository: CourseCategoryJpaRepository,
 ) : CourseStorageGateway {
     // FIXME: 업데이트 로직 분리
     override fun save(course: Course): Course {
-        val courseEntity = courseJpaRepository.save(CourseEntity.from(course))
+        val courseJpaEntity = courseJpaRepository.save(CourseJpaEntity.from(course))
         if (course.id == 0L) {
             course.categories
-                .map { CourseCategoryEntity.of(courseId = courseEntity.id!!, name = it.name) }
+                .map { CourseCategoryJpaEntity.of(courseId = courseJpaEntity.id!!, name = it.name) }
                 .also(courseCategoryJpaRepository::saveAll)
         }
         return course

--- a/src/main/kotlin/kr/wooco/woocobe/course/infrastructure/gateway/CourseStorageGatewayImpl.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/course/infrastructure/gateway/CourseStorageGatewayImpl.kt
@@ -4,8 +4,8 @@ import kr.wooco.woocobe.course.domain.gateway.CourseStorageGateway
 import kr.wooco.woocobe.course.domain.model.Course
 import kr.wooco.woocobe.course.domain.model.CourseRegion
 import kr.wooco.woocobe.course.domain.model.CourseSortCondition
-import kr.wooco.woocobe.course.infrastructure.storage.entity.CourseCategoryJpaEntity
-import kr.wooco.woocobe.course.infrastructure.storage.entity.CourseJpaEntity
+import kr.wooco.woocobe.course.infrastructure.storage.CourseCategoryStorageMapper
+import kr.wooco.woocobe.course.infrastructure.storage.CourseStorageMapper
 import kr.wooco.woocobe.course.infrastructure.storage.repository.CourseCategoryJpaRepository
 import kr.wooco.woocobe.course.infrastructure.storage.repository.CourseJpaRepository
 import org.springframework.data.repository.findByIdOrNull
@@ -15,65 +15,69 @@ import org.springframework.stereotype.Component
 class CourseStorageGatewayImpl(
     private val courseJpaRepository: CourseJpaRepository,
     private val courseCategoryJpaRepository: CourseCategoryJpaRepository,
+    private val courseStorageMapper: CourseStorageMapper,
+    private val courseCategoryStorageMapper: CourseCategoryStorageMapper,
 ) : CourseStorageGateway {
     // FIXME: 업데이트 로직 분리
     override fun save(course: Course): Course {
-        val courseJpaEntity = courseJpaRepository.save(CourseJpaEntity.from(course))
-        if (course.id == 0L) {
-            course.categories
-                .map { CourseCategoryJpaEntity.of(courseId = courseJpaEntity.id!!, name = it.name) }
-                .also(courseCategoryJpaRepository::saveAll)
-        }
-        return course
+        val courseEntity = courseStorageMapper.toEntity(course)
+        courseJpaRepository.save(courseEntity)
+        courseCategoryJpaRepository.deleteAllByCourseId(courseEntity.id!!)
+        val courseCategoryEntities = course.categories.map { courseCategoryStorageMapper.toEntity(courseEntity, it) }
+        courseCategoryJpaRepository.saveAll(courseCategoryEntities)
+        return courseStorageMapper.toDomain(courseEntity, courseCategoryEntities)
     }
 
-    override fun getByCourseId(courseId: Long): Course? =
-        courseJpaRepository.findByIdOrNull(courseId)?.let { courseEntity ->
-            courseEntity.toDomain(
-                courseCategory = courseCategoryJpaRepository
-                    .findAllByCourseId(courseEntity.id!!)
-                    .map { it.toDomain() },
-            )
-        }
+    override fun getByCourseId(courseId: Long): Course {
+        val courseEntity = courseJpaRepository.findByIdOrNull(courseId)
+            ?: throw RuntimeException()
+        val courseCategoryEntities = courseCategoryJpaRepository.findAllByCourseId(courseEntity.id!!)
+        return courseStorageMapper.toDomain(courseEntity, courseCategoryEntities)
+    }
 
     override fun getAllByCourseIds(courseIds: List<Long>): List<Course> {
-        TODO("Not yet implemented")
+        val courseEntities = courseJpaRepository.findAllById(courseIds)
+        val courseCategoryEntities = courseCategoryJpaRepository.findAllByCourseIdIn(courseIds)
+        return courseEntities.map { courseJpaEntity ->
+            courseStorageMapper.toDomain(
+                courseJpaEntity = courseJpaEntity,
+                courseCategoryJpaEntities = courseCategoryEntities.filter { it.courseId == courseJpaEntity.id },
+            )
+        }
     }
 
     override fun getAllByRegionAndCategoryWithSort(
         region: CourseRegion,
         category: String,
         sort: CourseSortCondition,
-    ): List<Course> =
-        courseJpaRepository
-            .findAllByRegionAndCategoryWithSort(region = region, category = category, sort = sort)
-            .run {
-                val categoryEntities = courseCategoryJpaRepository.findAllByCourseIdIn(map { it.id!! })
-                map { courseEntity ->
-                    courseEntity.toDomain(
-                        courseCategory = categoryEntities
-                            .filter { courseEntity.userId == it.courseId }
-                            .map { it.toDomain() },
-                    )
-                }
-            }
+    ): List<Course> {
+        val courseEntities =
+            courseJpaRepository.findAllByRegionAndCategoryWithSort(region = region, category = category, sort = sort)
+        val courseCategoryEntities = courseCategoryJpaRepository.findAllByCourseIdIn(courseEntities.map { it.id!! })
+        return courseEntities.map { courseJpaEntity ->
+            courseStorageMapper.toDomain(
+                courseJpaEntity = courseJpaEntity,
+                courseCategoryJpaEntities = courseCategoryEntities.filter { it.courseId == courseJpaEntity.id },
+            )
+        }
+    }
 
     override fun getAllByUserIdWithSort(
         userId: Long,
         sort: CourseSortCondition,
-    ): List<Course> =
-        courseJpaRepository
-            .findAllByUserIdWithSort(userId = userId, sort = sort)
-            .run {
-                val categoryEntities = courseCategoryJpaRepository.findAllByCourseIdIn(map { it.id!! })
-                map { courseEntity ->
-                    courseEntity.toDomain(
-                        courseCategory = categoryEntities
-                            .filter { courseEntity.userId == it.courseId }
-                            .map { it.toDomain() },
-                    )
-                }
-            }
+    ): List<Course> {
+        val courseEntities = courseJpaRepository.findAllByUserIdWithSort(userId = userId, sort = sort)
+        val courseCategoryEntities = courseCategoryJpaRepository.findAllByCourseIdIn(courseEntities.map { it.id!! })
+        return courseEntities.map { courseJpaEntity ->
+            courseStorageMapper.toDomain(
+                courseJpaEntity = courseJpaEntity,
+                courseCategoryJpaEntities = courseCategoryEntities.filter { it.courseId == courseJpaEntity.id },
+            )
+        }
+    }
 
-    override fun deleteByCourseId(courseId: Long) = courseJpaRepository.deleteById(courseId)
+    override fun deleteByCourseId(courseId: Long) {
+        courseJpaRepository.deleteById(courseId)
+        courseCategoryJpaRepository.deleteAllByCourseId(courseId)
+    }
 }

--- a/src/main/kotlin/kr/wooco/woocobe/course/infrastructure/gateway/InterestCourseStorageGatewayImpl.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/course/infrastructure/gateway/InterestCourseStorageGatewayImpl.kt
@@ -2,16 +2,16 @@ package kr.wooco.woocobe.course.infrastructure.gateway
 
 import kr.wooco.woocobe.course.domain.gateway.InterestCourseStorageGateway
 import kr.wooco.woocobe.course.domain.model.InterestCourse
-import kr.wooco.woocobe.course.infrastructure.storage.entity.InterestCourseEntity
+import kr.wooco.woocobe.course.infrastructure.storage.entity.InterestCourseJpaEntity
 import kr.wooco.woocobe.course.infrastructure.storage.repository.InterestCourseJpaRepository
 import org.springframework.stereotype.Component
 
 @Component
-class JpaInterestCourseStorageGateway(
+class InterestCourseStorageGatewayImpl(
     private val interestCourseJpaRepository: InterestCourseJpaRepository,
 ) : InterestCourseStorageGateway {
     override fun save(interestCourse: InterestCourse): InterestCourse =
-        interestCourseJpaRepository.save(InterestCourseEntity.from(interestCourse)).toDomain()
+        interestCourseJpaRepository.save(InterestCourseJpaEntity.from(interestCourse)).toDomain()
 
     override fun getByCourseIdAndUserId(
         courseId: Long,

--- a/src/main/kotlin/kr/wooco/woocobe/course/infrastructure/gateway/InterestCourseStorageGatewayImpl.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/course/infrastructure/gateway/InterestCourseStorageGatewayImpl.kt
@@ -7,7 +7,7 @@ import kr.wooco.woocobe.course.infrastructure.storage.repository.InterestCourseJ
 import org.springframework.stereotype.Component
 
 @Component
-class InterestCourseStorageGatewayImpl(
+internal class InterestCourseStorageGatewayImpl(
     private val interestCourseJpaRepository: InterestCourseJpaRepository,
     private val interestCourseStorageMapper: InterestCourseStorageMapper,
 ) : InterestCourseStorageGateway {

--- a/src/main/kotlin/kr/wooco/woocobe/course/infrastructure/gateway/InterestCourseStorageGatewayImpl.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/course/infrastructure/gateway/InterestCourseStorageGatewayImpl.kt
@@ -2,24 +2,34 @@ package kr.wooco.woocobe.course.infrastructure.gateway
 
 import kr.wooco.woocobe.course.domain.gateway.InterestCourseStorageGateway
 import kr.wooco.woocobe.course.domain.model.InterestCourse
-import kr.wooco.woocobe.course.infrastructure.storage.entity.InterestCourseJpaEntity
+import kr.wooco.woocobe.course.infrastructure.storage.InterestCourseStorageMapper
 import kr.wooco.woocobe.course.infrastructure.storage.repository.InterestCourseJpaRepository
 import org.springframework.stereotype.Component
 
 @Component
 class InterestCourseStorageGatewayImpl(
     private val interestCourseJpaRepository: InterestCourseJpaRepository,
+    private val interestCourseStorageMapper: InterestCourseStorageMapper,
 ) : InterestCourseStorageGateway {
-    override fun save(interestCourse: InterestCourse): InterestCourse =
-        interestCourseJpaRepository.save(InterestCourseJpaEntity.from(interestCourse)).toDomain()
+    override fun save(interestCourse: InterestCourse): InterestCourse {
+        val interestCourseEntity = interestCourseStorageMapper.toEntity(interestCourse)
+        interestCourseJpaRepository.save(interestCourseEntity)
+        return interestCourseStorageMapper.toDomain(interestCourseEntity)
+    }
 
     override fun getByCourseIdAndUserId(
         courseId: Long,
         userId: Long,
-    ): InterestCourse? = interestCourseJpaRepository.findByUserIdAndCourseId(userId, courseId)?.toDomain()
+    ): InterestCourse {
+        val interestCourseEntity = interestCourseJpaRepository.findByUserIdAndCourseId(userId, courseId)
+            ?: throw RuntimeException()
+        return interestCourseStorageMapper.toDomain(interestCourseEntity)
+    }
 
-    override fun getAllByUserId(userId: Long): List<InterestCourse> =
-        interestCourseJpaRepository.findAllByUserId(userId = userId).map { it.toDomain() }
+    override fun getAllByUserId(userId: Long): List<InterestCourse> {
+        val interestCourseEntities = interestCourseJpaRepository.findAllByUserId(userId = userId)
+        return interestCourseEntities.map { interestCourseStorageMapper.toDomain(it) }
+    }
 
     override fun existsByCourseIdAndUserId(
         courseId: Long,

--- a/src/main/kotlin/kr/wooco/woocobe/course/infrastructure/gateway/JpaCourseCommentStorageGateway.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/course/infrastructure/gateway/JpaCourseCommentStorageGateway.kt
@@ -2,36 +2,22 @@ package kr.wooco.woocobe.course.infrastructure.gateway
 
 import kr.wooco.woocobe.course.domain.gateway.CourseCommentStorageGateway
 import kr.wooco.woocobe.course.domain.model.CourseComment
-import kr.wooco.woocobe.course.infrastructure.storage.CourseCommentEntity
-import kr.wooco.woocobe.course.infrastructure.storage.CourseCommentJpaRepository
-import kr.wooco.woocobe.user.infrastructure.storage.UserJpaRepository
+import kr.wooco.woocobe.course.infrastructure.storage.entity.CourseCommentEntity
+import kr.wooco.woocobe.course.infrastructure.storage.repository.CourseCommentJpaRepository
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Component
 
 @Component
 class JpaCourseCommentStorageGateway(
-    private val userJpaRepository: UserJpaRepository,
     private val courseCommentJpaRepository: CourseCommentJpaRepository,
 ) : CourseCommentStorageGateway {
-    override fun save(courseComment: CourseComment): CourseComment {
-        courseCommentJpaRepository.save(CourseCommentEntity.from(courseComment))
-        return courseComment
-    }
+    override fun save(courseComment: CourseComment): CourseComment =
+        courseCommentJpaRepository.save(CourseCommentEntity.from(courseComment)).toDomain()
 
-    override fun getByCommentId(commentId: Long): CourseComment? =
-        courseCommentJpaRepository.findByIdOrNull(commentId)?.let {
-            it.toDomain(user = userJpaRepository.findByIdOrNull(it.userId)!!.toDomain())
-        }
+    override fun getByCommentId(commentId: Long): CourseComment? = courseCommentJpaRepository.findByIdOrNull(commentId)?.toDomain()
 
-    override fun getAllByCourseId(courseId: Long): List<CourseComment> {
-        val courseEntities = courseCommentJpaRepository.findAllByCourseId(courseId)
-        val userEntities = userJpaRepository.findAllById(courseEntities.map { it.userId })
-        return courseEntities.map { courseEntity ->
-            courseEntity.toDomain(
-                user = userEntities.find { it.id == courseEntity.userId }!!.toDomain(),
-            )
-        }
-    }
+    override fun getAllByCourseId(courseId: Long): List<CourseComment> =
+        courseCommentJpaRepository.findAllByCourseId(courseId).map { it.toDomain() }
 
     override fun deleteByCommentId(commentId: Long) = courseCommentJpaRepository.deleteById(commentId)
 }

--- a/src/main/kotlin/kr/wooco/woocobe/course/infrastructure/gateway/JpaInterestCourseStorageGateway.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/course/infrastructure/gateway/JpaInterestCourseStorageGateway.kt
@@ -2,60 +2,24 @@ package kr.wooco.woocobe.course.infrastructure.gateway
 
 import kr.wooco.woocobe.course.domain.gateway.InterestCourseStorageGateway
 import kr.wooco.woocobe.course.domain.model.InterestCourse
-import kr.wooco.woocobe.course.infrastructure.storage.CourseCategoryJpaRepository
-import kr.wooco.woocobe.course.infrastructure.storage.CourseJpaRepository
-import kr.wooco.woocobe.course.infrastructure.storage.InterestCourseEntity
-import kr.wooco.woocobe.course.infrastructure.storage.InterestCourseJpaRepository
-import kr.wooco.woocobe.user.infrastructure.storage.UserJpaRepository
-import org.springframework.data.repository.findByIdOrNull
+import kr.wooco.woocobe.course.infrastructure.storage.entity.InterestCourseEntity
+import kr.wooco.woocobe.course.infrastructure.storage.repository.InterestCourseJpaRepository
 import org.springframework.stereotype.Component
 
 @Component
-@Suppress("Duplicates") // TODO: 매퍼 클래스로 중복 제거
 class JpaInterestCourseStorageGateway(
-    private val userJpaRepository: UserJpaRepository,
-    private val courseJpaRepository: CourseJpaRepository,
-    private val courseCategoryJpaRepository: CourseCategoryJpaRepository,
     private val interestCourseJpaRepository: InterestCourseJpaRepository,
 ) : InterestCourseStorageGateway {
-    override fun save(interestCourse: InterestCourse): InterestCourse {
-        interestCourseJpaRepository.save(InterestCourseEntity.from(interestCourse))
-        return interestCourse
-    }
+    override fun save(interestCourse: InterestCourse): InterestCourse =
+        interestCourseJpaRepository.save(InterestCourseEntity.from(interestCourse)).toDomain()
 
     override fun getByCourseIdAndUserId(
-        userId: Long,
         courseId: Long,
-    ): InterestCourse? =
-        interestCourseJpaRepository
-            .findByUserIdAndCourseId(userId, courseId)
-            ?.let {
-                val user = userJpaRepository.findByIdOrNull(it.userId)!!.toDomain()
-                it.toDomain(course = courseJpaRepository.findByIdOrNull(courseId)!!.toDomain(user = user))
-            }
+        userId: Long,
+    ): InterestCourse? = interestCourseJpaRepository.findByUserIdAndCourseId(userId, courseId)?.toDomain()
 
-    override fun getAllByUserId(userId: Long): List<InterestCourse> {
-        val interestCourseEntities = interestCourseJpaRepository.findAllByUserId(userId = userId)
-        val courses = courseJpaRepository
-            .findAllById(interestCourseEntities.map { it.courseId })
-            .run {
-                val userEntities = userJpaRepository.findAllById(map { it.userId })
-                val categoryEntities = courseCategoryJpaRepository.findAllByCourseIdIn(map { it.id!! })
-                map { courseEntity ->
-                    courseEntity.toDomain(
-                        user = userEntities.find { courseEntity.userId == it.id }!!.toDomain(),
-                        courseCategory = categoryEntities
-                            .filter { courseEntity.userId == it.courseId }
-                            .map { it.toDomain() },
-                    )
-                }
-            }
-        return interestCourseEntities.map { interestCourseEntity ->
-            interestCourseEntity.toDomain(
-                course = courses.find { it.id == interestCourseEntity.courseId }!!,
-            )
-        }
-    }
+    override fun getAllByUserId(userId: Long): List<InterestCourse> =
+        interestCourseJpaRepository.findAllByUserId(userId = userId).map { it.toDomain() }
 
     override fun existsByCourseIdAndUserId(
         courseId: Long,

--- a/src/main/kotlin/kr/wooco/woocobe/course/infrastructure/storage/CourseCategoryStorageMapper.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/course/infrastructure/storage/CourseCategoryStorageMapper.kt
@@ -1,0 +1,18 @@
+package kr.wooco.woocobe.course.infrastructure.storage
+
+import kr.wooco.woocobe.course.domain.model.CourseCategory
+import kr.wooco.woocobe.course.infrastructure.storage.entity.CourseCategoryJpaEntity
+import kr.wooco.woocobe.course.infrastructure.storage.entity.CourseJpaEntity
+import org.springframework.stereotype.Component
+
+@Component
+class CourseCategoryStorageMapper {
+    fun toEntity(
+        courseJpaEntity: CourseJpaEntity,
+        courseCategory: CourseCategory,
+    ): CourseCategoryJpaEntity =
+        CourseCategoryJpaEntity(
+            courseId = courseJpaEntity.id!!,
+            name = courseCategory.name,
+        )
+}

--- a/src/main/kotlin/kr/wooco/woocobe/course/infrastructure/storage/CourseCommentStorageMapper.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/course/infrastructure/storage/CourseCommentStorageMapper.kt
@@ -1,0 +1,25 @@
+package kr.wooco.woocobe.course.infrastructure.storage
+
+import kr.wooco.woocobe.course.domain.model.CourseComment
+import kr.wooco.woocobe.course.infrastructure.storage.entity.CourseCommentJpaEntity
+import org.springframework.stereotype.Component
+
+@Component
+class CourseCommentStorageMapper {
+    fun toDomain(courseCommentJpaEntity: CourseCommentJpaEntity): CourseComment =
+        CourseComment(
+            id = courseCommentJpaEntity.id!!,
+            userId = courseCommentJpaEntity.userId,
+            courseId = courseCommentJpaEntity.courseId,
+            contents = courseCommentJpaEntity.contents,
+            commentDateTime = courseCommentJpaEntity.createdAt,
+        )
+
+    fun toEntity(courseComment: CourseComment): CourseCommentJpaEntity =
+        CourseCommentJpaEntity(
+            id = courseComment.id,
+            userId = courseComment.userId,
+            courseId = courseComment.courseId,
+            contents = courseComment.contents,
+        )
+}

--- a/src/main/kotlin/kr/wooco/woocobe/course/infrastructure/storage/CoursePlaceStorageMapper.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/course/infrastructure/storage/CoursePlaceStorageMapper.kt
@@ -1,0 +1,25 @@
+package kr.wooco.woocobe.course.infrastructure.storage
+
+import kr.wooco.woocobe.course.domain.model.CoursePlace
+import kr.wooco.woocobe.course.infrastructure.storage.entity.CourseJpaEntity
+import kr.wooco.woocobe.course.infrastructure.storage.entity.CoursePlaceJpaEntity
+import org.springframework.stereotype.Component
+
+@Component
+class CoursePlaceStorageMapper {
+    fun toDomain(coursePlaceJpaEntity: CoursePlaceJpaEntity): CoursePlace =
+        CoursePlace(
+            order = coursePlaceJpaEntity.order,
+            placeId = coursePlaceJpaEntity.placeId,
+        )
+
+    fun toEntity(
+        courseJpaEntity: CourseJpaEntity,
+        coursePlace: CoursePlace,
+    ): CoursePlaceJpaEntity =
+        CoursePlaceJpaEntity(
+            order = coursePlace.order,
+            courseId = courseJpaEntity.id!!,
+            placeId = coursePlace.placeId,
+        )
+}

--- a/src/main/kotlin/kr/wooco/woocobe/course/infrastructure/storage/CourseStorageMapper.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/course/infrastructure/storage/CourseStorageMapper.kt
@@ -2,15 +2,18 @@ package kr.wooco.woocobe.course.infrastructure.storage
 
 import kr.wooco.woocobe.course.domain.model.Course
 import kr.wooco.woocobe.course.domain.model.CourseCategory
+import kr.wooco.woocobe.course.domain.model.CoursePlace
 import kr.wooco.woocobe.course.domain.model.CourseRegion
 import kr.wooco.woocobe.course.infrastructure.storage.entity.CourseCategoryJpaEntity
 import kr.wooco.woocobe.course.infrastructure.storage.entity.CourseJpaEntity
+import kr.wooco.woocobe.course.infrastructure.storage.entity.CoursePlaceJpaEntity
 import org.springframework.stereotype.Component
 
 @Component
 class CourseStorageMapper {
     fun toDomain(
         courseJpaEntity: CourseJpaEntity,
+        coursePlaceJpaEntities: List<CoursePlaceJpaEntity>,
         courseCategoryJpaEntities: List<CourseCategoryJpaEntity>,
     ): Course =
         Course(
@@ -21,6 +24,7 @@ class CourseStorageMapper {
                 secondaryRegion = courseJpaEntity.secondaryRegion,
             ),
             categories = courseCategoryJpaEntities.map { CourseCategory.from(it.name) },
+            coursePlaces = coursePlaceJpaEntities.map { CoursePlace(order = it.order, placeId = it.placeId) },
             name = courseJpaEntity.name,
             contents = courseJpaEntity.contents,
             views = courseJpaEntity.viewCount,

--- a/src/main/kotlin/kr/wooco/woocobe/course/infrastructure/storage/CourseStorageMapper.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/course/infrastructure/storage/CourseStorageMapper.kt
@@ -1,0 +1,44 @@
+package kr.wooco.woocobe.course.infrastructure.storage
+
+import kr.wooco.woocobe.course.domain.model.Course
+import kr.wooco.woocobe.course.domain.model.CourseCategory
+import kr.wooco.woocobe.course.domain.model.CourseRegion
+import kr.wooco.woocobe.course.infrastructure.storage.entity.CourseCategoryJpaEntity
+import kr.wooco.woocobe.course.infrastructure.storage.entity.CourseJpaEntity
+import org.springframework.stereotype.Component
+
+@Component
+class CourseStorageMapper {
+    fun toDomain(
+        courseJpaEntity: CourseJpaEntity,
+        courseCategoryJpaEntities: List<CourseCategoryJpaEntity>,
+    ): Course =
+        Course(
+            id = courseJpaEntity.id!!,
+            userId = courseJpaEntity.userId,
+            region = CourseRegion(
+                primaryRegion = courseJpaEntity.primaryRegion,
+                secondaryRegion = courseJpaEntity.secondaryRegion,
+            ),
+            categories = courseCategoryJpaEntities.map { CourseCategory.from(it.name) },
+            name = courseJpaEntity.name,
+            contents = courseJpaEntity.contents,
+            views = courseJpaEntity.viewCount,
+            comments = courseJpaEntity.commentCount,
+            interests = courseJpaEntity.interestCount,
+            writeDateTime = courseJpaEntity.createdAt,
+        )
+
+    fun toEntity(course: Course): CourseJpaEntity =
+        CourseJpaEntity(
+            id = course.id,
+            userId = course.userId,
+            name = course.name,
+            primaryRegion = course.region.primaryRegion,
+            secondaryRegion = course.region.secondaryRegion,
+            contents = course.contents,
+            viewCount = course.views,
+            commentCount = course.comments,
+            interestCount = course.interests,
+        )
+}

--- a/src/main/kotlin/kr/wooco/woocobe/course/infrastructure/storage/InterestCourseStorageMapper.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/course/infrastructure/storage/InterestCourseStorageMapper.kt
@@ -1,0 +1,22 @@
+package kr.wooco.woocobe.course.infrastructure.storage
+
+import kr.wooco.woocobe.course.domain.model.InterestCourse
+import kr.wooco.woocobe.course.infrastructure.storage.entity.InterestCourseJpaEntity
+import org.springframework.stereotype.Component
+
+@Component
+class InterestCourseStorageMapper {
+    fun toDomain(interestCourseJpaEntity: InterestCourseJpaEntity): InterestCourse =
+        InterestCourse(
+            id = interestCourseJpaEntity.id!!,
+            userId = interestCourseJpaEntity.userId,
+            courseId = interestCourseJpaEntity.courseId,
+        )
+
+    fun toEntity(interestCourse: InterestCourse): InterestCourseJpaEntity =
+        InterestCourseJpaEntity(
+            id = interestCourse.id,
+            userId = interestCourse.userId,
+            courseId = interestCourse.courseId,
+        )
+}

--- a/src/main/kotlin/kr/wooco/woocobe/course/infrastructure/storage/entity/CourseCategoryEntity.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/course/infrastructure/storage/entity/CourseCategoryEntity.kt
@@ -1,4 +1,4 @@
-package kr.wooco.woocobe.course.infrastructure.storage
+package kr.wooco.woocobe.course.infrastructure.storage.entity
 
 import io.hypersistence.utils.hibernate.id.Tsid
 import jakarta.persistence.Column

--- a/src/main/kotlin/kr/wooco/woocobe/course/infrastructure/storage/entity/CourseCategoryJpaEntity.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/course/infrastructure/storage/entity/CourseCategoryJpaEntity.kt
@@ -6,7 +6,6 @@ import jakarta.persistence.Entity
 import jakarta.persistence.Id
 import jakarta.persistence.Table
 import kr.wooco.woocobe.common.infrastructure.storage.BaseTimeEntity
-import kr.wooco.woocobe.course.domain.model.CourseCategory
 
 @Entity
 @Table(name = "course_categories")
@@ -18,17 +17,4 @@ class CourseCategoryJpaEntity(
     @Id @Tsid
     @Column(name = "course_category_id")
     val id: Long? = 0L,
-) : BaseTimeEntity() {
-    fun toDomain(): CourseCategory = CourseCategory.entries.find { it.name == name }!!
-
-    companion object {
-        fun of(
-            courseId: Long,
-            name: String,
-        ): CourseCategoryJpaEntity =
-            CourseCategoryJpaEntity(
-                courseId = courseId,
-                name = name,
-            )
-    }
-}
+) : BaseTimeEntity()

--- a/src/main/kotlin/kr/wooco/woocobe/course/infrastructure/storage/entity/CourseCategoryJpaEntity.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/course/infrastructure/storage/entity/CourseCategoryJpaEntity.kt
@@ -10,7 +10,7 @@ import kr.wooco.woocobe.course.domain.model.CourseCategory
 
 @Entity
 @Table(name = "course_categories")
-class CourseCategoryEntity(
+class CourseCategoryJpaEntity(
     @Column(name = "category_name")
     val name: String,
     @Column(name = "course_id")
@@ -25,8 +25,8 @@ class CourseCategoryEntity(
         fun of(
             courseId: Long,
             name: String,
-        ): CourseCategoryEntity =
-            CourseCategoryEntity(
+        ): CourseCategoryJpaEntity =
+            CourseCategoryJpaEntity(
                 courseId = courseId,
                 name = name,
             )

--- a/src/main/kotlin/kr/wooco/woocobe/course/infrastructure/storage/entity/CourseCommentEntity.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/course/infrastructure/storage/entity/CourseCommentEntity.kt
@@ -1,4 +1,4 @@
-package kr.wooco.woocobe.course.infrastructure.storage
+package kr.wooco.woocobe.course.infrastructure.storage.entity
 
 import io.hypersistence.utils.hibernate.id.Tsid
 import jakarta.persistence.Column
@@ -7,7 +7,6 @@ import jakarta.persistence.Id
 import jakarta.persistence.Table
 import kr.wooco.woocobe.common.infrastructure.storage.BaseTimeEntity
 import kr.wooco.woocobe.course.domain.model.CourseComment
-import kr.wooco.woocobe.user.domain.model.User
 
 @Entity
 @Table(name = "course_comments")
@@ -22,10 +21,10 @@ class CourseCommentEntity(
     @Column(name = "course_comment_id")
     val id: Long? = 0L,
 ) : BaseTimeEntity() {
-    fun toDomain(user: User): CourseComment =
+    fun toDomain(): CourseComment =
         CourseComment(
             id = id!!,
-            user = user,
+            userId = userId,
             courseId = courseId,
             contents = contents,
             commentDateTime = createdAt,
@@ -36,7 +35,7 @@ class CourseCommentEntity(
             with(courseComment) {
                 CourseCommentEntity(
                     id = id,
-                    userId = user.id,
+                    userId = userId,
                     courseId = courseId,
                     contents = contents,
                 )

--- a/src/main/kotlin/kr/wooco/woocobe/course/infrastructure/storage/entity/CourseCommentJpaEntity.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/course/infrastructure/storage/entity/CourseCommentJpaEntity.kt
@@ -6,7 +6,6 @@ import jakarta.persistence.Entity
 import jakarta.persistence.Id
 import jakarta.persistence.Table
 import kr.wooco.woocobe.common.infrastructure.storage.BaseTimeEntity
-import kr.wooco.woocobe.course.domain.model.CourseComment
 
 @Entity
 @Table(name = "course_comments")
@@ -20,25 +19,4 @@ class CourseCommentJpaEntity(
     @Id @Tsid
     @Column(name = "course_comment_id")
     val id: Long? = 0L,
-) : BaseTimeEntity() {
-    fun toDomain(): CourseComment =
-        CourseComment(
-            id = id!!,
-            userId = userId,
-            courseId = courseId,
-            contents = contents,
-            commentDateTime = createdAt,
-        )
-
-    companion object {
-        fun from(courseComment: CourseComment): CourseCommentJpaEntity =
-            with(courseComment) {
-                CourseCommentJpaEntity(
-                    id = id,
-                    userId = userId,
-                    courseId = courseId,
-                    contents = contents,
-                )
-            }
-    }
-}
+) : BaseTimeEntity()

--- a/src/main/kotlin/kr/wooco/woocobe/course/infrastructure/storage/entity/CourseCommentJpaEntity.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/course/infrastructure/storage/entity/CourseCommentJpaEntity.kt
@@ -10,7 +10,7 @@ import kr.wooco.woocobe.course.domain.model.CourseComment
 
 @Entity
 @Table(name = "course_comments")
-class CourseCommentEntity(
+class CourseCommentJpaEntity(
     @Column(columnDefinition = "text")
     val contents: String,
     @Column(name = "course_id")
@@ -31,9 +31,9 @@ class CourseCommentEntity(
         )
 
     companion object {
-        fun from(courseComment: CourseComment): CourseCommentEntity =
+        fun from(courseComment: CourseComment): CourseCommentJpaEntity =
             with(courseComment) {
-                CourseCommentEntity(
+                CourseCommentJpaEntity(
                     id = id,
                     userId = userId,
                     courseId = courseId,

--- a/src/main/kotlin/kr/wooco/woocobe/course/infrastructure/storage/entity/CourseEntity.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/course/infrastructure/storage/entity/CourseEntity.kt
@@ -1,4 +1,4 @@
-package kr.wooco.woocobe.course.infrastructure.storage
+package kr.wooco.woocobe.course.infrastructure.storage.entity
 
 import io.hypersistence.utils.hibernate.id.Tsid
 import jakarta.persistence.Column
@@ -9,7 +9,6 @@ import kr.wooco.woocobe.common.infrastructure.storage.BaseTimeEntity
 import kr.wooco.woocobe.course.domain.model.Course
 import kr.wooco.woocobe.course.domain.model.CourseCategory
 import kr.wooco.woocobe.course.domain.model.CourseRegion
-import kr.wooco.woocobe.user.domain.model.User
 
 @Entity
 @Table(name = "courses")
@@ -34,13 +33,10 @@ class CourseEntity(
     @Column(name = "course_id", nullable = false)
     val id: Long? = 0L,
 ) : BaseTimeEntity() {
-    fun toDomain(
-        user: User,
-        courseCategory: List<CourseCategory> = emptyList(),
-    ): Course =
+    fun toDomain(courseCategory: List<CourseCategory> = emptyList()): Course =
         Course(
             id = id!!,
-            user = user,
+            userId = userId,
             region = CourseRegion(
                 primaryRegion = primaryRegion,
                 secondaryRegion = secondaryRegion,
@@ -59,7 +55,7 @@ class CourseEntity(
             with(course) {
                 CourseEntity(
                     id = id,
-                    userId = user.id,
+                    userId = userId,
                     name = name,
                     primaryRegion = region.primaryRegion,
                     secondaryRegion = region.secondaryRegion,

--- a/src/main/kotlin/kr/wooco/woocobe/course/infrastructure/storage/entity/CourseJpaEntity.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/course/infrastructure/storage/entity/CourseJpaEntity.kt
@@ -12,7 +12,7 @@ import kr.wooco.woocobe.course.domain.model.CourseRegion
 
 @Entity
 @Table(name = "courses")
-class CourseEntity(
+class CourseJpaEntity(
     @Column(name = "comment_count")
     val commentCount: Long,
     @Column(name = "interest_count")
@@ -51,9 +51,9 @@ class CourseEntity(
         )
 
     companion object {
-        fun from(course: Course): CourseEntity =
+        fun from(course: Course): CourseJpaEntity =
             with(course) {
-                CourseEntity(
+                CourseJpaEntity(
                     id = id,
                     userId = userId,
                     name = name,

--- a/src/main/kotlin/kr/wooco/woocobe/course/infrastructure/storage/entity/CourseJpaEntity.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/course/infrastructure/storage/entity/CourseJpaEntity.kt
@@ -6,9 +6,6 @@ import jakarta.persistence.Entity
 import jakarta.persistence.Id
 import jakarta.persistence.Table
 import kr.wooco.woocobe.common.infrastructure.storage.BaseTimeEntity
-import kr.wooco.woocobe.course.domain.model.Course
-import kr.wooco.woocobe.course.domain.model.CourseCategory
-import kr.wooco.woocobe.course.domain.model.CourseRegion
 
 @Entity
 @Table(name = "courses")
@@ -32,38 +29,4 @@ class CourseJpaEntity(
     @Id @Tsid
     @Column(name = "course_id", nullable = false)
     val id: Long? = 0L,
-) : BaseTimeEntity() {
-    fun toDomain(courseCategory: List<CourseCategory> = emptyList()): Course =
-        Course(
-            id = id!!,
-            userId = userId,
-            region = CourseRegion(
-                primaryRegion = primaryRegion,
-                secondaryRegion = secondaryRegion,
-            ),
-            writeDateTime = createdAt,
-            categories = courseCategory.map { CourseCategory.from(it.name) },
-            name = name,
-            contents = contents,
-            views = viewCount,
-            comments = commentCount,
-            interests = interestCount,
-        )
-
-    companion object {
-        fun from(course: Course): CourseJpaEntity =
-            with(course) {
-                CourseJpaEntity(
-                    id = id,
-                    userId = userId,
-                    name = name,
-                    primaryRegion = region.primaryRegion,
-                    secondaryRegion = region.secondaryRegion,
-                    contents = contents,
-                    viewCount = views,
-                    commentCount = comments,
-                    interestCount = interests,
-                )
-            }
-    }
-}
+) : BaseTimeEntity()

--- a/src/main/kotlin/kr/wooco/woocobe/course/infrastructure/storage/entity/CoursePlaceJpaEntity.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/course/infrastructure/storage/entity/CoursePlaceJpaEntity.kt
@@ -1,0 +1,22 @@
+package kr.wooco.woocobe.course.infrastructure.storage.entity
+
+import io.hypersistence.utils.hibernate.id.Tsid
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import kr.wooco.woocobe.common.infrastructure.storage.BaseTimeEntity
+
+@Entity
+@Table(name = "course_places")
+class CoursePlaceJpaEntity(
+    @Column(name = "order")
+    val order: Int,
+    @Column(name = "course_id")
+    val courseId: Long,
+    @Column(name = "place_id")
+    val placeId: Long,
+    @Id @Tsid
+    @Column(name = "course_place_id")
+    val id: Long? = 0L,
+) : BaseTimeEntity()

--- a/src/main/kotlin/kr/wooco/woocobe/course/infrastructure/storage/entity/InterestCourseEntity.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/course/infrastructure/storage/entity/InterestCourseEntity.kt
@@ -1,4 +1,4 @@
-package kr.wooco.woocobe.course.infrastructure.storage
+package kr.wooco.woocobe.course.infrastructure.storage.entity
 
 import io.hypersistence.utils.hibernate.id.Tsid
 import jakarta.persistence.Column
@@ -6,7 +6,6 @@ import jakarta.persistence.Entity
 import jakarta.persistence.Id
 import jakarta.persistence.Table
 import kr.wooco.woocobe.common.infrastructure.storage.BaseTimeEntity
-import kr.wooco.woocobe.course.domain.model.Course
 import kr.wooco.woocobe.course.domain.model.InterestCourse
 
 @Entity
@@ -20,11 +19,11 @@ class InterestCourseEntity(
     @Column(name = "interest_course_id")
     val id: Long? = 0L,
 ) : BaseTimeEntity() {
-    fun toDomain(course: Course): InterestCourse =
+    fun toDomain(): InterestCourse =
         InterestCourse(
             id = id!!,
             userId = userId,
-            course = course,
+            courseId = courseId,
         )
 
     companion object {
@@ -33,7 +32,7 @@ class InterestCourseEntity(
                 InterestCourseEntity(
                     id = id,
                     userId = userId,
-                    courseId = course.id,
+                    courseId = courseId,
                 )
             }
     }

--- a/src/main/kotlin/kr/wooco/woocobe/course/infrastructure/storage/entity/InterestCourseJpaEntity.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/course/infrastructure/storage/entity/InterestCourseJpaEntity.kt
@@ -10,7 +10,7 @@ import kr.wooco.woocobe.course.domain.model.InterestCourse
 
 @Entity
 @Table(name = "interest_course")
-class InterestCourseEntity(
+class InterestCourseJpaEntity(
     @Column(name = "course_id")
     val courseId: Long,
     @Column(name = "interest_user_id")
@@ -27,9 +27,9 @@ class InterestCourseEntity(
         )
 
     companion object {
-        fun from(interestCourse: InterestCourse): InterestCourseEntity =
+        fun from(interestCourse: InterestCourse): InterestCourseJpaEntity =
             with(interestCourse) {
-                InterestCourseEntity(
+                InterestCourseJpaEntity(
                     id = id,
                     userId = userId,
                     courseId = courseId,

--- a/src/main/kotlin/kr/wooco/woocobe/course/infrastructure/storage/entity/InterestCourseJpaEntity.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/course/infrastructure/storage/entity/InterestCourseJpaEntity.kt
@@ -6,7 +6,6 @@ import jakarta.persistence.Entity
 import jakarta.persistence.Id
 import jakarta.persistence.Table
 import kr.wooco.woocobe.common.infrastructure.storage.BaseTimeEntity
-import kr.wooco.woocobe.course.domain.model.InterestCourse
 
 @Entity
 @Table(name = "interest_course")
@@ -18,22 +17,4 @@ class InterestCourseJpaEntity(
     @Id @Tsid
     @Column(name = "interest_course_id")
     val id: Long? = 0L,
-) : BaseTimeEntity() {
-    fun toDomain(): InterestCourse =
-        InterestCourse(
-            id = id!!,
-            userId = userId,
-            courseId = courseId,
-        )
-
-    companion object {
-        fun from(interestCourse: InterestCourse): InterestCourseJpaEntity =
-            with(interestCourse) {
-                InterestCourseJpaEntity(
-                    id = id,
-                    userId = userId,
-                    courseId = courseId,
-                )
-            }
-    }
-}
+) : BaseTimeEntity()

--- a/src/main/kotlin/kr/wooco/woocobe/course/infrastructure/storage/repository/CourseCategoryJpaRepository.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/course/infrastructure/storage/repository/CourseCategoryJpaRepository.kt
@@ -7,4 +7,6 @@ interface CourseCategoryJpaRepository : JpaRepository<CourseCategoryJpaEntity, L
     fun findAllByCourseId(courseId: Long): List<CourseCategoryJpaEntity>
 
     fun findAllByCourseIdIn(courseIds: List<Long>): List<CourseCategoryJpaEntity>
+
+    fun deleteAllByCourseId(courseId: Long)
 }

--- a/src/main/kotlin/kr/wooco/woocobe/course/infrastructure/storage/repository/CourseCategoryJpaRepository.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/course/infrastructure/storage/repository/CourseCategoryJpaRepository.kt
@@ -1,5 +1,6 @@
-package kr.wooco.woocobe.course.infrastructure.storage
+package kr.wooco.woocobe.course.infrastructure.storage.repository
 
+import kr.wooco.woocobe.course.infrastructure.storage.entity.CourseCategoryEntity
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface CourseCategoryJpaRepository : JpaRepository<CourseCategoryEntity, Long> {

--- a/src/main/kotlin/kr/wooco/woocobe/course/infrastructure/storage/repository/CourseCategoryJpaRepository.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/course/infrastructure/storage/repository/CourseCategoryJpaRepository.kt
@@ -1,10 +1,10 @@
 package kr.wooco.woocobe.course.infrastructure.storage.repository
 
-import kr.wooco.woocobe.course.infrastructure.storage.entity.CourseCategoryEntity
+import kr.wooco.woocobe.course.infrastructure.storage.entity.CourseCategoryJpaEntity
 import org.springframework.data.jpa.repository.JpaRepository
 
-interface CourseCategoryJpaRepository : JpaRepository<CourseCategoryEntity, Long> {
-    fun findAllByCourseId(courseId: Long): List<CourseCategoryEntity>
+interface CourseCategoryJpaRepository : JpaRepository<CourseCategoryJpaEntity, Long> {
+    fun findAllByCourseId(courseId: Long): List<CourseCategoryJpaEntity>
 
-    fun findAllByCourseIdIn(courseIds: List<Long>): List<CourseCategoryEntity>
+    fun findAllByCourseIdIn(courseIds: List<Long>): List<CourseCategoryJpaEntity>
 }

--- a/src/main/kotlin/kr/wooco/woocobe/course/infrastructure/storage/repository/CourseCommentJpaRepository.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/course/infrastructure/storage/repository/CourseCommentJpaRepository.kt
@@ -1,8 +1,8 @@
 package kr.wooco.woocobe.course.infrastructure.storage.repository
 
-import kr.wooco.woocobe.course.infrastructure.storage.entity.CourseCommentEntity
+import kr.wooco.woocobe.course.infrastructure.storage.entity.CourseCommentJpaEntity
 import org.springframework.data.jpa.repository.JpaRepository
 
-interface CourseCommentJpaRepository : JpaRepository<CourseCommentEntity, Long> {
-    fun findAllByCourseId(courseId: Long): List<CourseCommentEntity>
+interface CourseCommentJpaRepository : JpaRepository<CourseCommentJpaEntity, Long> {
+    fun findAllByCourseId(courseId: Long): List<CourseCommentJpaEntity>
 }

--- a/src/main/kotlin/kr/wooco/woocobe/course/infrastructure/storage/repository/CourseCommentJpaRepository.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/course/infrastructure/storage/repository/CourseCommentJpaRepository.kt
@@ -1,5 +1,6 @@
-package kr.wooco.woocobe.course.infrastructure.storage
+package kr.wooco.woocobe.course.infrastructure.storage.repository
 
+import kr.wooco.woocobe.course.infrastructure.storage.entity.CourseCommentEntity
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface CourseCommentJpaRepository : JpaRepository<CourseCommentEntity, Long> {

--- a/src/main/kotlin/kr/wooco/woocobe/course/infrastructure/storage/repository/CourseCustomRepository.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/course/infrastructure/storage/repository/CourseCustomRepository.kt
@@ -1,7 +1,8 @@
-package kr.wooco.woocobe.course.infrastructure.storage
+package kr.wooco.woocobe.course.infrastructure.storage.repository
 
 import kr.wooco.woocobe.course.domain.model.CourseRegion
 import kr.wooco.woocobe.course.domain.model.CourseSortCondition
+import kr.wooco.woocobe.course.infrastructure.storage.entity.CourseEntity
 
 interface CourseCustomRepository {
     fun findAllByUserIdWithSort(

--- a/src/main/kotlin/kr/wooco/woocobe/course/infrastructure/storage/repository/CourseCustomRepository.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/course/infrastructure/storage/repository/CourseCustomRepository.kt
@@ -12,7 +12,7 @@ interface CourseCustomRepository {
 
     fun findAllByRegionAndCategoryWithSort(
         region: CourseRegion,
-        category: String,
+        category: String?,
         sort: CourseSortCondition,
     ): List<CourseJpaEntity>
 }

--- a/src/main/kotlin/kr/wooco/woocobe/course/infrastructure/storage/repository/CourseCustomRepository.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/course/infrastructure/storage/repository/CourseCustomRepository.kt
@@ -2,17 +2,17 @@ package kr.wooco.woocobe.course.infrastructure.storage.repository
 
 import kr.wooco.woocobe.course.domain.model.CourseRegion
 import kr.wooco.woocobe.course.domain.model.CourseSortCondition
-import kr.wooco.woocobe.course.infrastructure.storage.entity.CourseEntity
+import kr.wooco.woocobe.course.infrastructure.storage.entity.CourseJpaEntity
 
 interface CourseCustomRepository {
     fun findAllByUserIdWithSort(
         userId: Long,
         sort: CourseSortCondition,
-    ): List<CourseEntity>
+    ): List<CourseJpaEntity>
 
     fun findAllByRegionAndCategoryWithSort(
         region: CourseRegion,
         category: String,
         sort: CourseSortCondition,
-    ): List<CourseEntity>
+    ): List<CourseJpaEntity>
 }

--- a/src/main/kotlin/kr/wooco/woocobe/course/infrastructure/storage/repository/CourseCustomRepositoryImpl.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/course/infrastructure/storage/repository/CourseCustomRepositoryImpl.kt
@@ -3,8 +3,8 @@ package kr.wooco.woocobe.course.infrastructure.storage.repository
 import com.linecorp.kotlinjdsl.support.spring.data.jpa.repository.KotlinJdslJpqlExecutor
 import kr.wooco.woocobe.course.domain.model.CourseRegion
 import kr.wooco.woocobe.course.domain.model.CourseSortCondition
-import kr.wooco.woocobe.course.infrastructure.storage.entity.CourseCategoryEntity
-import kr.wooco.woocobe.course.infrastructure.storage.entity.CourseEntity
+import kr.wooco.woocobe.course.infrastructure.storage.entity.CourseCategoryJpaEntity
+import kr.wooco.woocobe.course.infrastructure.storage.entity.CourseJpaEntity
 import kr.wooco.woocobe.user.infrastructure.storage.UserEntity
 import org.springframework.stereotype.Repository
 
@@ -15,25 +15,25 @@ class CourseCustomRepositoryImpl(
     override fun findAllByUserIdWithSort(
         userId: Long,
         sort: CourseSortCondition,
-    ): List<CourseEntity> =
+    ): List<CourseJpaEntity> =
         executor
             .findAll {
                 select(
-                    entity(CourseEntity::class),
+                    entity(CourseJpaEntity::class),
                 ).from(
-                    entity(CourseEntity::class),
-                    leftJoin(CourseCategoryEntity::class).on(
-                        path(CourseEntity::id).eq(path(CourseCategoryEntity::courseId)),
+                    entity(CourseJpaEntity::class),
+                    leftJoin(CourseCategoryJpaEntity::class).on(
+                        path(CourseJpaEntity::id).eq(path(CourseCategoryJpaEntity::courseId)),
                     ),
                     leftJoin(UserEntity::class).on(
-                        path(CourseEntity::userId).eq(path(UserEntity::id)),
+                        path(CourseJpaEntity::userId).eq(path(UserEntity::id)),
                     ),
                 ).whereAnd(
-                    path(CourseEntity::userId).eq(path(UserEntity::id)),
+                    path(CourseJpaEntity::userId).eq(path(UserEntity::id)),
                 ).orderBy(
                     when (sort) {
-                        CourseSortCondition.POPULAR -> path(CourseEntity::viewCount).desc()
-                        CourseSortCondition.RECENT -> path(CourseEntity::createdAt).desc()
+                        CourseSortCondition.POPULAR -> path(CourseJpaEntity::viewCount).desc()
+                        CourseSortCondition.RECENT -> path(CourseJpaEntity::createdAt).desc()
                     },
                 )
             }.filterNotNull()
@@ -42,27 +42,27 @@ class CourseCustomRepositoryImpl(
         region: CourseRegion,
         category: String,
         sort: CourseSortCondition,
-    ): List<CourseEntity> =
+    ): List<CourseJpaEntity> =
         executor
             .findAll {
                 select(
-                    entity(CourseEntity::class),
+                    entity(CourseJpaEntity::class),
                 ).from(
-                    entity(CourseEntity::class),
-                    leftJoin(CourseCategoryEntity::class).on(
-                        path(CourseEntity::id).eq(path(CourseCategoryEntity::courseId)),
+                    entity(CourseJpaEntity::class),
+                    leftJoin(CourseCategoryJpaEntity::class).on(
+                        path(CourseJpaEntity::id).eq(path(CourseCategoryJpaEntity::courseId)),
                     ),
                     leftJoin(UserEntity::class).on(
-                        path(CourseEntity::userId).eq(path(UserEntity::id)),
+                        path(CourseJpaEntity::userId).eq(path(UserEntity::id)),
                     ),
                 ).whereAnd(
-                    path(CourseEntity::primaryRegion).eq(region.primaryRegion),
-                    path(CourseEntity::secondaryRegion).eq(region.secondaryRegion),
-                    path(CourseCategoryEntity::name).eq(category),
+                    path(CourseJpaEntity::primaryRegion).eq(region.primaryRegion),
+                    path(CourseJpaEntity::secondaryRegion).eq(region.secondaryRegion),
+                    path(CourseCategoryJpaEntity::name).eq(category),
                 ).orderBy(
                     when (sort) {
-                        CourseSortCondition.POPULAR -> path(CourseEntity::viewCount).desc()
-                        CourseSortCondition.RECENT -> path(CourseEntity::createdAt).desc()
+                        CourseSortCondition.POPULAR -> path(CourseJpaEntity::viewCount).desc()
+                        CourseSortCondition.RECENT -> path(CourseJpaEntity::createdAt).desc()
                     },
                 )
             }.filterNotNull()

--- a/src/main/kotlin/kr/wooco/woocobe/course/infrastructure/storage/repository/CourseCustomRepositoryImpl.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/course/infrastructure/storage/repository/CourseCustomRepositoryImpl.kt
@@ -5,7 +5,6 @@ import kr.wooco.woocobe.course.domain.model.CourseRegion
 import kr.wooco.woocobe.course.domain.model.CourseSortCondition
 import kr.wooco.woocobe.course.infrastructure.storage.entity.CourseCategoryJpaEntity
 import kr.wooco.woocobe.course.infrastructure.storage.entity.CourseJpaEntity
-import kr.wooco.woocobe.user.infrastructure.storage.UserEntity
 import org.springframework.stereotype.Repository
 
 @Repository
@@ -22,14 +21,8 @@ class CourseCustomRepositoryImpl(
                     entity(CourseJpaEntity::class),
                 ).from(
                     entity(CourseJpaEntity::class),
-                    leftJoin(CourseCategoryJpaEntity::class).on(
-                        path(CourseJpaEntity::id).eq(path(CourseCategoryJpaEntity::courseId)),
-                    ),
-                    leftJoin(UserEntity::class).on(
-                        path(CourseJpaEntity::userId).eq(path(UserEntity::id)),
-                    ),
                 ).whereAnd(
-                    path(CourseJpaEntity::userId).eq(path(UserEntity::id)),
+                    path(CourseJpaEntity::userId).eq(userId),
                 ).orderBy(
                     when (sort) {
                         CourseSortCondition.POPULAR -> path(CourseJpaEntity::viewCount).desc()
@@ -40,7 +33,7 @@ class CourseCustomRepositoryImpl(
 
     override fun findAllByRegionAndCategoryWithSort(
         region: CourseRegion,
-        category: String,
+        category: String?,
         sort: CourseSortCondition,
     ): List<CourseJpaEntity> =
         executor
@@ -52,13 +45,12 @@ class CourseCustomRepositoryImpl(
                     leftJoin(CourseCategoryJpaEntity::class).on(
                         path(CourseJpaEntity::id).eq(path(CourseCategoryJpaEntity::courseId)),
                     ),
-                    leftJoin(UserEntity::class).on(
-                        path(CourseJpaEntity::userId).eq(path(UserEntity::id)),
-                    ),
                 ).whereAnd(
                     path(CourseJpaEntity::primaryRegion).eq(region.primaryRegion),
                     path(CourseJpaEntity::secondaryRegion).eq(region.secondaryRegion),
-                    path(CourseCategoryJpaEntity::name).eq(category),
+                    category?.let {
+                        path(CourseCategoryJpaEntity::name).eq(category)
+                    },
                 ).orderBy(
                     when (sort) {
                         CourseSortCondition.POPULAR -> path(CourseJpaEntity::viewCount).desc()

--- a/src/main/kotlin/kr/wooco/woocobe/course/infrastructure/storage/repository/CourseCustomRepositoryImpl.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/course/infrastructure/storage/repository/CourseCustomRepositoryImpl.kt
@@ -1,8 +1,10 @@
-package kr.wooco.woocobe.course.infrastructure.storage
+package kr.wooco.woocobe.course.infrastructure.storage.repository
 
 import com.linecorp.kotlinjdsl.support.spring.data.jpa.repository.KotlinJdslJpqlExecutor
 import kr.wooco.woocobe.course.domain.model.CourseRegion
 import kr.wooco.woocobe.course.domain.model.CourseSortCondition
+import kr.wooco.woocobe.course.infrastructure.storage.entity.CourseCategoryEntity
+import kr.wooco.woocobe.course.infrastructure.storage.entity.CourseEntity
 import kr.wooco.woocobe.user.infrastructure.storage.UserEntity
 import org.springframework.stereotype.Repository
 

--- a/src/main/kotlin/kr/wooco/woocobe/course/infrastructure/storage/repository/CourseJpaRepository.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/course/infrastructure/storage/repository/CourseJpaRepository.kt
@@ -1,5 +1,6 @@
-package kr.wooco.woocobe.course.infrastructure.storage
+package kr.wooco.woocobe.course.infrastructure.storage.repository
 
+import kr.wooco.woocobe.course.infrastructure.storage.entity.CourseEntity
 import org.springframework.data.jpa.repository.JpaRepository
 
 @Suppress("ktlint")

--- a/src/main/kotlin/kr/wooco/woocobe/course/infrastructure/storage/repository/CourseJpaRepository.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/course/infrastructure/storage/repository/CourseJpaRepository.kt
@@ -1,7 +1,7 @@
 package kr.wooco.woocobe.course.infrastructure.storage.repository
 
-import kr.wooco.woocobe.course.infrastructure.storage.entity.CourseEntity
+import kr.wooco.woocobe.course.infrastructure.storage.entity.CourseJpaEntity
 import org.springframework.data.jpa.repository.JpaRepository
 
 @Suppress("ktlint")
-interface CourseJpaRepository : JpaRepository<CourseEntity, Long>, CourseCustomRepository
+interface CourseJpaRepository : JpaRepository<CourseJpaEntity, Long>, CourseCustomRepository

--- a/src/main/kotlin/kr/wooco/woocobe/course/infrastructure/storage/repository/CoursePlaceJpaRepository.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/course/infrastructure/storage/repository/CoursePlaceJpaRepository.kt
@@ -1,0 +1,12 @@
+package kr.wooco.woocobe.course.infrastructure.storage.repository
+
+import kr.wooco.woocobe.course.infrastructure.storage.entity.CoursePlaceJpaEntity
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface CoursePlaceJpaRepository : JpaRepository<CoursePlaceJpaEntity, Long> {
+    fun findAllByCourseId(courseId: Long): List<CoursePlaceJpaEntity>
+
+    fun findAllByCourseIdIn(courseIds: List<Long>): List<CoursePlaceJpaEntity>
+
+    fun deleteAllByCourseId(courseId: Long)
+}

--- a/src/main/kotlin/kr/wooco/woocobe/course/infrastructure/storage/repository/InterestCourseJpaRepository.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/course/infrastructure/storage/repository/InterestCourseJpaRepository.kt
@@ -1,5 +1,6 @@
-package kr.wooco.woocobe.course.infrastructure.storage
+package kr.wooco.woocobe.course.infrastructure.storage.repository
 
+import kr.wooco.woocobe.course.infrastructure.storage.entity.InterestCourseEntity
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 

--- a/src/main/kotlin/kr/wooco/woocobe/course/infrastructure/storage/repository/InterestCourseJpaRepository.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/course/infrastructure/storage/repository/InterestCourseJpaRepository.kt
@@ -1,20 +1,20 @@
 package kr.wooco.woocobe.course.infrastructure.storage.repository
 
-import kr.wooco.woocobe.course.infrastructure.storage.entity.InterestCourseEntity
+import kr.wooco.woocobe.course.infrastructure.storage.entity.InterestCourseJpaEntity
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 
-interface InterestCourseJpaRepository : JpaRepository<InterestCourseEntity, Long> {
+interface InterestCourseJpaRepository : JpaRepository<InterestCourseJpaEntity, Long> {
     fun findByUserIdAndCourseId(
         userId: Long,
         courseId: Long,
-    ): InterestCourseEntity?
+    ): InterestCourseJpaEntity?
 
     @Query(
         """
             SELECT CASE WHEN EXISTS (
                 SELECT 1
-                FROM InterestCourseEntity ic
+                FROM InterestCourseJpaEntity ic
                 WHERE ic.courseId = :courseId
                     AND ic.userId = :userId
             ) THEN true ELSE false END
@@ -25,5 +25,5 @@ interface InterestCourseJpaRepository : JpaRepository<InterestCourseEntity, Long
         userId: Long,
     ): Boolean
 
-    fun findAllByUserId(userId: Long): List<InterestCourseEntity>
+    fun findAllByUserId(userId: Long): List<InterestCourseJpaEntity>
 }

--- a/src/main/kotlin/kr/wooco/woocobe/course/ui/web/controller/CourseApiController.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/course/ui/web/controller/CourseApiController.kt
@@ -1,0 +1,5 @@
+package kr.wooco.woocobe.course.ui.web.controller
+
+// TODO: 구현 - 스웨거용 인터페이스
+
+interface CourseApiController

--- a/src/main/kotlin/kr/wooco/woocobe/course/ui/web/controller/CourseController.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/course/ui/web/controller/CourseController.kt
@@ -1,0 +1,13 @@
+package kr.wooco.woocobe.course.ui.web.controller
+
+import kr.wooco.woocobe.course.ui.web.facade.CourseFacadeService
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+// TODO: 구현
+
+@RestController
+@RequestMapping("/api/v1/courses")
+class CourseController(
+    private val courseFacadeService: CourseFacadeService,
+) : CourseApiController

--- a/src/main/kotlin/kr/wooco/woocobe/course/ui/web/facade/CourseFacadeService.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/course/ui/web/facade/CourseFacadeService.kt
@@ -1,0 +1,8 @@
+package kr.wooco.woocobe.course.ui.web.facade
+
+import org.springframework.stereotype.Service
+
+// TODO: 구현 - 다른 애그리거트들의 usecase 들과 협업(조합)하여 사용할 수 있다.
+
+@Service
+class CourseFacadeService


### PR DESCRIPTION
## 📝 개요

<!-- 이 PR의 목적과 관련된 정보를 간략히 설명합니다. -->

코스 기능의 인프라에서 매퍼 로직과 함께 코스 플레이스 기능을 추가합니다.

또한, 직접 참조로 인해 인프라 로직과 도메인 기능이 모두 복잡해지는 현상을 없애기 위해 직접 참조에서 간접 참조로 변경함으로써 해당 도메인에만 집중할 수 있도록 수정합니다.

직접 참조에서 간접 참조로 변환됨으로 써, 다른 애그리거트의 기능이 필요한 부분은 `facade` 레이어에서 usecase를 조합하여 사용하는 방향으로 진행합니다.

## ✨ 변경 사항

<!-- 코드나 기능의 주요 변경 사항을 설명 -->

- ✨ `gateway` 메서드 non-nullable하게 변경
- ✨ `gateway` 구현체 네이밍 `impl` 로 통일
- ✨ `mapper` 클래스 추가
- ✨ 다른 애그리거트를 직접 참조하던 방식을 간접 참조 방식으로 전환
- ✨ `ui` 패키지에 대한 새로운 레이어 컨벤션 추가
- ✨ 코스 플레이스 기능 추가

## 🔗 관련 이슈

<!-- 이 PR과 관련된 이슈 번호를 연결 (없으면 생략) -->

- closed #39 

## ℹ️ 참고 사항

<!-- 리뷰어가 알 필요가 있는 추가 정보나 문서, 참고 링크를 포함 (없으면 생략) -->

**대 격 변**

코스 엔티티에서 코스 카테고리와 코스 장소의 생명주기가 **항상 동일 할 것으로 예상**되어 코스엔티티, 코스 카테고리, 코스 장소 위 3개에 대해서 연관관계를 걸어서 사용하는게 더 좋을 것 같다는 생각이듭니다.
