### PR TITLE
feat: 이미지 업로드 기능 추가

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -41,6 +41,7 @@ dependencies {
     implementation("com.linecorp.kotlin-jdsl:jpql-render:${property("jdslVersion")}")
     implementation("com.linecorp.kotlin-jdsl:spring-data-jpa-support:${property("jdslVersion")}")
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:${property("springDocVersion")}")
+    implementation("io.awspring.cloud:spring-cloud-aws-starter-s3:${property("awsS3Version")}")
     runtimeOnly("com.mysql:mysql-connector-j")
     runtimeOnly("io.jsonwebtoken:jjwt-impl:${property("jjwtVersion")}")
     runtimeOnly("io.jsonwebtoken:jjwt-jackson:${property("jjwtVersion")}")

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,34 +1,27 @@
 ### Application ###
 projectGroup=kr.wooco
 applicationVersion=0.0.1
-
 ### Kotlin ###
 kotlinVersion=1.9.25
 kotlinLoggingVersion=7.0.0
-
 ### Ktlint ###
 ktlintVersion=12.1.0
-
 ### Spring ###
 springBootVersion=3.3.6
 springDependencyManagementVersion=1.1.6
-
+### AWS ###
+awsS3Version=3.2.1
 ### Swagger ###
 springDocVersion=2.6.0
-
 ### JDSL ###
 jdslVersion=3.5.4
-
 ### Jwt ###
 jjwtVersion=0.11.4
-
 ### TSID ###
 tsidVersion=3.9.0
 tsidCreatorVersion=5.2.6
-
 ### Kotest ###
 kotestVersion=5.8.1
 kotestExtensionsVersion=1.3.0
-
 ### Mockk ###
 mockkVersion=1.13.13

--- a/src/main/kotlin/kr/wooco/woocobe/image/domain/gateway/ImageClientGateway.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/image/domain/gateway/ImageClientGateway.kt
@@ -1,0 +1,7 @@
+package kr.wooco.woocobe.image.domain.gateway
+
+import kr.wooco.woocobe.image.domain.model.ImageKey
+
+interface ImageClientGateway {
+    fun fetchImageUploadUrl(imageKey: ImageKey): String
+}

--- a/src/main/kotlin/kr/wooco/woocobe/image/domain/model/Image.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/image/domain/model/Image.kt
@@ -1,0 +1,16 @@
+package kr.wooco.woocobe.image.domain.model
+
+data class Image(
+    val imagePath: String,
+    val uploadUrl: String,
+) {
+    constructor(imageKey: ImageKey, uploadUrl: String) : this(
+        imagePath = imageKey.key,
+        uploadUrl = uploadUrl,
+    )
+
+    init {
+        require(imagePath.isNotBlank()) { "imageUrl cannot be blank" }
+        require(uploadUrl.isNotBlank()) { "uploadUrl cannot be blank" }
+    }
+}

--- a/src/main/kotlin/kr/wooco/woocobe/image/domain/model/ImageKey.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/image/domain/model/ImageKey.kt
@@ -1,0 +1,17 @@
+package kr.wooco.woocobe.image.domain.model
+
+import java.util.UUID
+
+data class ImageKey(
+    val key: String,
+) {
+    constructor(userId: Long) : this(
+        key = "$userId$KEY_DELIMITER${generateRandomKey()}",
+    )
+
+    companion object {
+        private const val KEY_DELIMITER = "/"
+
+        private fun generateRandomKey(): String = UUID.randomUUID().toString()
+    }
+}

--- a/src/main/kotlin/kr/wooco/woocobe/image/domain/usecase/GetImageUploadUrlUseCase.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/image/domain/usecase/GetImageUploadUrlUseCase.kt
@@ -1,0 +1,31 @@
+package kr.wooco.woocobe.image.domain.usecase
+
+import kr.wooco.woocobe.common.domain.usecase.UseCase
+import kr.wooco.woocobe.image.domain.gateway.ImageClientGateway
+import kr.wooco.woocobe.image.domain.model.Image
+import kr.wooco.woocobe.image.domain.model.ImageKey
+import org.springframework.stereotype.Service
+
+data class GetImageUploadUrlInput(
+    val userId: Long,
+)
+
+data class GetImageUploadUrlOutput(
+    val image: Image,
+)
+
+@Service
+class GetImageUploadUrlUseCase(
+    private val imageClientGateway: ImageClientGateway,
+) : UseCase<GetImageUploadUrlInput, GetImageUploadUrlOutput> {
+    override fun execute(input: GetImageUploadUrlInput): GetImageUploadUrlOutput {
+        val imageKey = ImageKey(input.userId)
+        val uploadUrl = imageClientGateway.fetchImageUploadUrl(imageKey)
+
+        val image = Image(imageKey, uploadUrl)
+
+        return GetImageUploadUrlOutput(
+            image = image,
+        )
+    }
+}

--- a/src/main/kotlin/kr/wooco/woocobe/image/infrastructure/client/S3ClientHandler.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/image/infrastructure/client/S3ClientHandler.kt
@@ -1,0 +1,42 @@
+package kr.wooco.woocobe.image.infrastructure.client
+
+import org.springframework.stereotype.Component
+import software.amazon.awssdk.services.s3.model.Delete
+import software.amazon.awssdk.services.s3.model.DeleteObjectsRequest
+import software.amazon.awssdk.services.s3.model.PutObjectRequest
+import software.amazon.awssdk.services.s3.presigner.S3Presigner
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest
+
+@Component
+class S3ClientHandler(
+    private val s3Presigner: S3Presigner,
+    private val s3ClientProperties: S3ClientProperties,
+) {
+    fun generatePresignedUrl(key: String): String {
+        val putObjectRequest = PutObjectRequest.builder().build {
+            key(key)
+            bucket(s3ClientProperties.bucketName)
+            contentType(s3ClientProperties.contentType)
+        }
+
+        val presignRequest = PutObjectPresignRequest.builder().build {
+            putObjectRequest(putObjectRequest)
+            signatureDuration(s3ClientProperties.timeout)
+        }
+
+        DeleteObjectsRequest
+            .builder()
+            .bucket(s3ClientProperties.bucketName)
+            .delete(Delete.builder().objects(listOf()).build())
+            .build()
+
+        return s3Presigner.presignPutObject(presignRequest).url().toString()
+    }
+}
+
+// Extension Methods
+private inline fun PutObjectRequest.Builder.build(options: PutObjectRequest.Builder.() -> Unit): PutObjectRequest =
+    PutObjectRequest.builder().apply(options).build()
+
+private inline fun PutObjectPresignRequest.Builder.build(options: PutObjectPresignRequest.Builder.() -> Unit): PutObjectPresignRequest =
+    PutObjectPresignRequest.builder().apply(options).build()

--- a/src/main/kotlin/kr/wooco/woocobe/image/infrastructure/client/S3ClientProperties.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/image/infrastructure/client/S3ClientProperties.kt
@@ -1,0 +1,11 @@
+package kr.wooco.woocobe.image.infrastructure.client
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import java.time.Duration
+
+@ConfigurationProperties(prefix = "app.aws.s3")
+data class S3ClientProperties(
+    val bucketName: String,
+    val contentType: String,
+    val timeout: Duration,
+)

--- a/src/main/kotlin/kr/wooco/woocobe/image/infrastructure/gateway/ImageClientGatewayImpl.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/image/infrastructure/gateway/ImageClientGatewayImpl.kt
@@ -1,0 +1,13 @@
+package kr.wooco.woocobe.image.infrastructure.gateway
+
+import kr.wooco.woocobe.image.domain.gateway.ImageClientGateway
+import kr.wooco.woocobe.image.domain.model.ImageKey
+import kr.wooco.woocobe.image.infrastructure.client.S3ClientHandler
+import org.springframework.stereotype.Component
+
+@Component
+internal class ImageClientGatewayImpl(
+    private val s3ClientHandler: S3ClientHandler,
+) : ImageClientGateway {
+    override fun fetchImageUploadUrl(imageKey: ImageKey): String = s3ClientHandler.generatePresignedUrl(imageKey.key)
+}

--- a/src/main/kotlin/kr/wooco/woocobe/image/ui/web/controller/ImageApi.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/image/ui/web/controller/ImageApi.kt
@@ -1,0 +1,8 @@
+package kr.wooco.woocobe.image.ui.web.controller
+
+import kr.wooco.woocobe.image.ui.web.controller.response.ImageUploadUrlResponse
+import org.springframework.http.ResponseEntity
+
+interface ImageApi {
+    fun getUploadUrl(userId: Long): ResponseEntity<ImageUploadUrlResponse>
+}

--- a/src/main/kotlin/kr/wooco/woocobe/image/ui/web/controller/ImageController.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/image/ui/web/controller/ImageController.kt
@@ -1,0 +1,23 @@
+package kr.wooco.woocobe.image.ui.web.controller
+
+import kr.wooco.woocobe.image.ui.web.controller.response.ImageUploadUrlResponse
+import kr.wooco.woocobe.image.ui.web.facade.ImageFacadeService
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/images")
+class ImageController(
+    private val imageFacadeService: ImageFacadeService,
+) : ImageApi {
+    @GetMapping("/upload/url")
+    override fun getUploadUrl(
+        @AuthenticationPrincipal userId: Long,
+    ): ResponseEntity<ImageUploadUrlResponse> {
+        val response = imageFacadeService.getImageUploadUrl(userId)
+        return ResponseEntity.ok(response)
+    }
+}

--- a/src/main/kotlin/kr/wooco/woocobe/image/ui/web/controller/response/ImageUploadUrlResponse.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/image/ui/web/controller/response/ImageUploadUrlResponse.kt
@@ -1,0 +1,6 @@
+package kr.wooco.woocobe.image.ui.web.controller.response
+
+data class ImageUploadUrlResponse(
+    val imagePath: String,
+    val uploadUrl: String,
+)

--- a/src/main/kotlin/kr/wooco/woocobe/image/ui/web/facade/ImageFacadeService.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/image/ui/web/facade/ImageFacadeService.kt
@@ -1,0 +1,21 @@
+package kr.wooco.woocobe.image.ui.web.facade
+
+import kr.wooco.woocobe.image.domain.usecase.GetImageUploadUrlInput
+import kr.wooco.woocobe.image.domain.usecase.GetImageUploadUrlUseCase
+import kr.wooco.woocobe.image.ui.web.controller.response.ImageUploadUrlResponse
+import org.springframework.stereotype.Service
+
+@Service
+class ImageFacadeService(
+    private val getImageUploadUrlUseCase: GetImageUploadUrlUseCase,
+) {
+    fun getImageUploadUrl(userId: Long): ImageUploadUrlResponse {
+        val result = getImageUploadUrlUseCase.execute(
+            GetImageUploadUrlInput(userId = userId),
+        )
+        return ImageUploadUrlResponse(
+            imagePath = result.image.imagePath,
+            uploadUrl = result.image.uploadUrl,
+        )
+    }
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -30,12 +30,26 @@ spring:
       repositories:
         enabled: false
 
+  cloud:
+    aws:
+      region:
+        static: ap-northeast-2
+      credentials:
+        access-key: ${AWS_ACCESS_KEY}
+        secret-key: ${AWS_SECRET_KEY}
+
   security:
     user:
       name: local-actuator
       password: local-actuator
 
 app:
+  aws:
+    s3:
+      bucket-name: ${AWS_S3_BUCKET_NAME}
+      content-type: image/webp
+      timeout: 60s
+
   jwt:
     signing-key: hong-jun2-eric-erica-jamie-hong-jun2-eric-erica-jamie
     expiration:

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -31,12 +31,26 @@ spring:
       repositories:
         enabled: false
 
+  cloud:
+    aws:
+      region:
+        static: ap-northeast-2
+      credentials:
+        access-key: ABCDEFGHIJKLMNOPQRST
+        secret-key: 1234567890abcdefghijklmnopqrstuvwxyz1234
+
   security:
     user:
       name: local
       password: local
 
 app:
+  aws:
+    s3:
+      bucket-name: mock-s3
+      content-type: image/webp
+      timeout: 60s
+
   jwt:
     signing-key: hong-jun2-eric-erica-jamie-hong-jun2-eric-erica-jamie
     expiration:


### PR DESCRIPTION
## 📝 개요

<!-- 이 PR의 목적과 관련된 정보를 간략히 설명합니다. -->

이미지 업로드 기능을 추가합니다.

## ✨ 변경 사항

<!-- 코드나 기능의 주요 변경 사항을 설명 -->

- ✨ AWS S3 의존성 추가
- ✨ Presinged URL 발급 로직 추가

## 🔗 관련 이슈

<!-- 이 PR과 관련된 이슈 번호를 연결 (없으면 생략) -->

- closed #67 

## ℹ️ 참고 사항

<!-- 리뷰어가 알 필요가 있는 추가 정보나 문서, 참고 링크를 포함 (없으면 생략) -->

`ui/web/controller` 패키지안에 `request` 및 `response` 패키지를 두려고 했는데, facade에서 실제 response 객체를 만들어 반환해서 `ui/web` 경로에 `request` 및 `response` 를 두는 방향으로 가야할 것 같습니다.

일단 초기 컨벤션과 일치하기 위해서 `ui/web/controller` 패키지 안에 정의해두고 facade 에서 `ui/web/controller/response`를 참조하도록 구현해놨습니다.
