### PR TITLE
refactor: 엔티티 식별자 채번 전략 및 기본 엔티티 클래스 수정

### DIFF
--- a/src/main/kotlin/kr/wooco/woocobe/common/infrastructure/storage/BaseTimeEntity.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/common/infrastructure/storage/BaseTimeEntity.kt
@@ -8,6 +8,13 @@ import org.springframework.data.annotation.LastModifiedDate
 import org.springframework.data.jpa.domain.support.AuditingEntityListener
 import java.time.LocalDateTime
 
+@Deprecated(
+    message = "entity 패키지내에 정의된 BaseTimeEntity로 변경해주세요.",
+    replaceWith = ReplaceWith(
+        "BaseTimeEntity",
+        "kr.wooco.woocowe.common.infrastructure.storage.entity.BaseTimeEntity",
+    ),
+)
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener::class)
 abstract class BaseTimeEntity {

--- a/src/main/kotlin/kr/wooco/woocobe/common/infrastructure/storage/IdGenerator.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/common/infrastructure/storage/IdGenerator.kt
@@ -2,6 +2,7 @@ package kr.wooco.woocobe.common.infrastructure.storage
 
 import com.github.f4b6a3.tsid.TsidFactory
 
+@Deprecated(message = "이 클래스는 더 이상 사용하지 않습니다.")
 object IdGenerator {
     private val tsidFactory: TsidFactory = TsidFactory
         .builder()

--- a/src/main/kotlin/kr/wooco/woocobe/common/infrastructure/storage/IdGeneratorConfig.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/common/infrastructure/storage/IdGeneratorConfig.kt
@@ -4,6 +4,7 @@ import jakarta.annotation.PostConstruct
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Configuration
 
+@Deprecated(message = "이 클래스는 더 이상 사용하지 않습니다.")
 @Configuration
 class IdGeneratorConfig(
     @Value("\${server.node}") private val nodeNumber: Int,

--- a/src/main/kotlin/kr/wooco/woocobe/common/infrastructure/storage/TsidConfig.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/common/infrastructure/storage/TsidConfig.kt
@@ -1,0 +1,18 @@
+package kr.wooco.woocobe.common.infrastructure.storage
+
+import com.github.f4b6a3.tsid.TsidCreator
+import org.hibernate.annotations.IdGeneratorType
+import org.hibernate.engine.spi.SharedSessionContractImplementor
+import org.hibernate.id.IdentifierGenerator
+
+internal class TsidGenerator : IdentifierGenerator {
+    override fun generate(
+        session: SharedSessionContractImplementor?,
+        `object`: Any?,
+    ): Any = TsidCreator.getTsid().toLong()
+}
+
+@IdGeneratorType(TsidGenerator::class)
+@Target(AnnotationTarget.FIELD, AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class Tsid

--- a/src/main/kotlin/kr/wooco/woocobe/common/infrastructure/storage/entity/BaseEntity.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/common/infrastructure/storage/entity/BaseEntity.kt
@@ -1,0 +1,28 @@
+package kr.wooco.woocobe.common.infrastructure.storage.entity
+
+import jakarta.persistence.MappedSuperclass
+import org.hibernate.proxy.HibernateProxy
+import org.springframework.data.domain.Persistable
+
+@MappedSuperclass
+abstract class BaseEntity : Persistable<Long> {
+    abstract val id: Long
+
+    override fun getId(): Long = id
+
+    override fun isNew(): Boolean = id == 0L
+
+    override fun equals(other: Any?): Boolean {
+        if (other == null) return false
+
+        if (other !is HibernateProxy && this::class != other::class) return false
+
+        return when (other) {
+            is HibernateProxy -> id == other.hibernateLazyInitializer.identifier
+            is BaseEntity -> id == other.id
+            else -> false
+        }
+    }
+
+    override fun hashCode() = id.hashCode()
+}

--- a/src/main/kotlin/kr/wooco/woocobe/common/infrastructure/storage/entity/BaseTimeEntity.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/common/infrastructure/storage/entity/BaseTimeEntity.kt
@@ -1,0 +1,21 @@
+package kr.wooco.woocobe.common.infrastructure.storage.entity
+
+import jakarta.persistence.Column
+import jakarta.persistence.EntityListeners
+import jakarta.persistence.MappedSuperclass
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import java.time.LocalDateTime
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener::class)
+abstract class BaseTimeEntity : BaseEntity() {
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    var createdAt: LocalDateTime = LocalDateTime.now()
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    var updatedAt: LocalDateTime = LocalDateTime.now()
+}


### PR DESCRIPTION
## 📝 개요

<!-- 이 PR의 목적과 관련된 정보를 간략히 설명합니다. -->

TSID 채번 어노테이션 클래스 추가와 기본 엔티티 클래스를 추가합니다.
기존에 사용하고 있는 기본 엔티티 클래스는 `@Deprecated` 어노테이션 추가했습니다.

## ✨ 변경 사항

<!-- 코드나 기능의 주요 변경 사항을 설명 -->

- ✨ 커스텀 `TSID` 채번 어노테이션 추가
- ✨ 기본 엔티티 클래스 추가
- ✨ 기존에 사용하던 기본 엔티티 클래스 `@Deprecated` 추가

## 🔗 관련 이슈

<!-- 이 PR과 관련된 이슈 번호를 연결 (없으면 생략) -->

- closed #72 

## ℹ️ 참고 사항

<!-- 리뷰어가 알 필요가 있는 추가 정보나 문서, 참고 링크를 포함 (없으면 생략) -->

- 
