### PR TITLE
refactor: 플랜 식별자 생성 전략 수정

### DIFF
--- a/src/main/kotlin/kr/wooco/woocobe/plan/infrastructure/gateway/PlanStorageGatewayImpl.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/plan/infrastructure/gateway/PlanStorageGatewayImpl.kt
@@ -23,11 +23,11 @@ internal class PlanStorageGatewayImpl(
     override fun save(plan: Plan): Plan {
         val planEntity = planJpaRepository.save(planStorageMapper.toEntity(plan))
 
-        planPlaceJpaRepository.deleteAllByPlanId(planEntity.id!!)
+        planPlaceJpaRepository.deleteAllByPlanId(planEntity.id)
         val planPlaceEntities = plan.places.map { planPlaceStorageMapper.toEntity(planEntity, it) }
         planPlaceJpaRepository.saveAll(planPlaceEntities)
 
-        planCategoryJpaRepository.deleteAllByPlanId(planEntity.id!!)
+        planCategoryJpaRepository.deleteAllByPlanId(planEntity.id)
         val planCategoryEntities = plan.categories.map { planCategoryStorageMapper.toEntity(planEntity, it) }
         planCategoryJpaRepository.saveAll(planCategoryEntities)
 
@@ -45,7 +45,7 @@ internal class PlanStorageGatewayImpl(
 
     override fun getAllByUserId(userId: Long): List<Plan> {
         val planEntities = planJpaRepository.findAllByUserId(userId)
-        val planIds = planEntities.map { it.id!! }
+        val planIds = planEntities.map { it.id }
         val planPlaceEntities = planPlaceJpaRepository.findAllByPlanIdIn(planIds)
         val planCategoryEntities = planCategoryJpaRepository.findAllByPlanIdIn(planIds)
 

--- a/src/main/kotlin/kr/wooco/woocobe/plan/infrastructure/storage/PlanCategoryStorageMapper.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/plan/infrastructure/storage/PlanCategoryStorageMapper.kt
@@ -12,7 +12,7 @@ class PlanCategoryStorageMapper {
         planCategory: PlanCategory,
     ): PlanCategoryJpaEntity =
         PlanCategoryJpaEntity(
-            planId = planJpaEntity.id!!,
+            planId = planJpaEntity.id,
             name = planCategory.name,
         )
 }

--- a/src/main/kotlin/kr/wooco/woocobe/plan/infrastructure/storage/PlanPlaceStorageMapper.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/plan/infrastructure/storage/PlanPlaceStorageMapper.kt
@@ -19,7 +19,7 @@ class PlanPlaceStorageMapper {
     ): PlanPlaceJpaEntity =
         PlanPlaceJpaEntity(
             order = planPlace.order,
-            planId = planJpaEntity.id!!,
+            planId = planJpaEntity.id,
             placeId = planPlace.placeId,
         )
 }

--- a/src/main/kotlin/kr/wooco/woocobe/plan/infrastructure/storage/PlanStorageMapper.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/plan/infrastructure/storage/PlanStorageMapper.kt
@@ -17,7 +17,7 @@ class PlanStorageMapper {
         planCategoryJpaEntities: List<PlanCategoryJpaEntity>,
     ): Plan =
         Plan(
-            id = planJpaEntity.id!!,
+            id = planJpaEntity.id,
             userId = planJpaEntity.userId,
             title = planJpaEntity.title,
             description = planJpaEntity.description,
@@ -26,7 +26,7 @@ class PlanStorageMapper {
                 secondaryRegion = planJpaEntity.secondaryRegion,
             ),
             visitDate = planJpaEntity.visitDate,
-            places = planPlaceJpaEntities.map { PlanPlace(order = it.order, placeId = it.planId) },
+            places = planPlaceJpaEntities.map { PlanPlace(order = it.order, placeId = it.placeId) },
             categories = planCategoryJpaEntities.map { PlanCategory.from(it.name.uppercase()) },
         )
 

--- a/src/main/kotlin/kr/wooco/woocobe/plan/infrastructure/storage/entity/PlanCategoryJpaEntity.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/plan/infrastructure/storage/entity/PlanCategoryJpaEntity.kt
@@ -1,11 +1,11 @@
 package kr.wooco.woocobe.plan.infrastructure.storage.entity
 
-import io.hypersistence.utils.hibernate.id.Tsid
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.Id
 import jakarta.persistence.Table
-import kr.wooco.woocobe.common.infrastructure.storage.BaseTimeEntity
+import kr.wooco.woocobe.common.infrastructure.storage.Tsid
+import kr.wooco.woocobe.common.infrastructure.storage.entity.BaseTimeEntity
 
 @Entity
 @Table(name = "plan_categories")
@@ -16,5 +16,5 @@ class PlanCategoryJpaEntity(
     val name: String,
     @Id @Tsid
     @Column(name = "plan_category_id")
-    val id: Long? = 0L,
+    override val id: Long = 0L,
 ) : BaseTimeEntity()

--- a/src/main/kotlin/kr/wooco/woocobe/plan/infrastructure/storage/entity/PlanJpaEntity.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/plan/infrastructure/storage/entity/PlanJpaEntity.kt
@@ -1,11 +1,11 @@
 package kr.wooco.woocobe.plan.infrastructure.storage.entity
 
-import io.hypersistence.utils.hibernate.id.Tsid
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.Id
 import jakarta.persistence.Table
-import kr.wooco.woocobe.common.infrastructure.storage.BaseTimeEntity
+import kr.wooco.woocobe.common.infrastructure.storage.Tsid
+import kr.wooco.woocobe.common.infrastructure.storage.entity.BaseTimeEntity
 import java.time.LocalDate
 
 @Entity
@@ -25,5 +25,5 @@ class PlanJpaEntity(
     val visitDate: LocalDate,
     @Id @Tsid
     @Column(name = "plan_id")
-    val id: Long? = 0L,
+    override val id: Long = 0L,
 ) : BaseTimeEntity()

--- a/src/main/kotlin/kr/wooco/woocobe/plan/infrastructure/storage/entity/PlanPlaceJpaEntity.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/plan/infrastructure/storage/entity/PlanPlaceJpaEntity.kt
@@ -1,11 +1,11 @@
 package kr.wooco.woocobe.plan.infrastructure.storage.entity
 
-import io.hypersistence.utils.hibernate.id.Tsid
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.Id
 import jakarta.persistence.Table
-import kr.wooco.woocobe.common.infrastructure.storage.BaseTimeEntity
+import kr.wooco.woocobe.common.infrastructure.storage.Tsid
+import kr.wooco.woocobe.common.infrastructure.storage.entity.BaseTimeEntity
 
 @Entity
 @Table(name = "plan_places")
@@ -17,5 +17,5 @@ class PlanPlaceJpaEntity(
     @Column(name = "place_id")
     val placeId: Long,
     @Id @Tsid
-    val id: Long? = 0L,
+    override val id: Long = 0L,
 ) : BaseTimeEntity()


### PR DESCRIPTION
## 📝 개요

식별자 생성 전략이 변경됨에 따라 플랜 도메인의 엔티티 클래스 또한 변경하였습니다.

## ✨ 변경 사항

- ✨ 플랜 도메인 내 엔티티 클래스 BaseTimeEntity 변경
- ✨ 플랜 도메인 내 엔티티 클래스 @Tsid 변경
- ✨ 엔티티 클래스 변경에 따른 불필요한 연산자 (!!) 제거
- ✨ 플랜 조회시 잘못된 장소 아이디 값이 반환되던 오류 해결

## 🔗 관련 이슈

- closed #77 

## ℹ️ 참고 사항

