### PR TITLE
refactor: 장소 도메인 메서드 컨벤션 수정 및 리팩토링

### DIFF
--- a/src/main/kotlin/kr/wooco/woocobe/place/domain/gateway/PlaceStorageGateway.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/domain/gateway/PlaceStorageGateway.kt
@@ -8,7 +8,7 @@ interface PlaceStorageGateway {
 
     fun getByPlaceId(placeId: Long): Place
 
-    fun getByKakaoMapPlaceIdOrNull(kakaoMapPlaceId: String): Place?
+    fun getOrNullByKakaoMapPlaceId(kakaoMapPlaceId: String): Place?
 
     fun getAllByPlaceIds(placeIds: List<Long>): List<Place>
 

--- a/src/main/kotlin/kr/wooco/woocobe/place/domain/gateway/PlaceStorageGateway.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/domain/gateway/PlaceStorageGateway.kt
@@ -8,7 +8,7 @@ interface PlaceStorageGateway {
 
     fun getByPlaceId(placeId: Long): Place
 
-    fun getByKakaoMapPlaceId(kakaoMapPlaceId: String): Place?
+    fun getByKakaoMapPlaceIdOrNull(kakaoMapPlaceId: String): Place?
 
     fun getAllByPlaceIds(placeIds: List<Long>): List<Place>
 

--- a/src/main/kotlin/kr/wooco/woocobe/place/domain/model/Place.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/domain/model/Place.kt
@@ -24,12 +24,9 @@ class Place(
         currentReviewRate: Double,
         reviewRate: Double,
     ) {
-        if (reviewCount > 0) {
-            averageRating =
-                ((averageRating * reviewCount) - currentReviewRate + reviewRate) / reviewCount
-        } else {
-            averageRating = 0.0
-            reviewCount = 0
+        averageRating = when (reviewCount) {
+            0L -> 0.0
+            else -> ((averageRating * reviewCount) - currentReviewRate + reviewRate) / reviewCount
         }
     }
 

--- a/src/main/kotlin/kr/wooco/woocobe/place/domain/model/Place.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/domain/model/Place.kt
@@ -10,12 +10,12 @@ class Place(
     var averageRating: Double,
     var reviewCount: Long,
 ) {
-    fun increaseStats(newRating: Double) {
+    fun increasePlaceStats(newRating: Double) {
         averageRating = ((averageRating * reviewCount) + newRating) / (reviewCount + 1)
         reviewCount++
     }
 
-    fun updateStats(
+    fun processPlaceStats(
         oldRating: Double,
         newRating: Double,
     ) {
@@ -24,7 +24,7 @@ class Place(
         }
     }
 
-    fun decreaseStats(oldRating: Double) {
+    fun decreasePlaceStats(oldRating: Double) {
         if (reviewCount > 1) {
             averageRating = ((averageRating * reviewCount) - oldRating) / (reviewCount - 1)
             reviewCount--

--- a/src/main/kotlin/kr/wooco/woocobe/place/domain/model/Place.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/domain/model/Place.kt
@@ -15,7 +15,7 @@ class Place(
     }
 
     fun decreaseReviewCounts() {
-        if (reviewCount > 1) {
+        if (reviewCount > 0) {
             reviewCount--
         }
     }

--- a/src/main/kotlin/kr/wooco/woocobe/place/domain/model/Place.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/domain/model/Place.kt
@@ -10,12 +10,12 @@ class Place(
     var averageRating: Double,
     var reviewCount: Long,
 ) {
-    fun addReview(newRating: Double) {
+    fun increaseStats(newRating: Double) {
         averageRating = ((averageRating * reviewCount) + newRating) / (reviewCount + 1)
         reviewCount++
     }
 
-    fun updateReview(
+    fun updateStats(
         oldRating: Double,
         newRating: Double,
     ) {
@@ -24,7 +24,7 @@ class Place(
         }
     }
 
-    fun deleteReview(oldRating: Double) {
+    fun decreaseStats(oldRating: Double) {
         if (reviewCount > 1) {
             averageRating = ((averageRating * reviewCount) - oldRating) / (reviewCount - 1)
             reviewCount--

--- a/src/main/kotlin/kr/wooco/woocobe/place/domain/model/Place.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/domain/model/Place.kt
@@ -10,27 +10,26 @@ class Place(
     var averageRating: Double,
     var reviewCount: Long,
 ) {
-    fun increasePlaceStats(newRating: Double) {
-        averageRating = ((averageRating * reviewCount) + newRating) / (reviewCount + 1)
+    fun increaseReviewCounts() {
         reviewCount++
     }
 
-    fun processPlaceStats(
-        oldRating: Double,
-        newRating: Double,
-    ) {
-        if (reviewCount > 0) {
-            averageRating += (newRating - oldRating) / reviewCount
-        }
-    }
-
-    fun decreasePlaceStats(oldRating: Double) {
+    fun decreaseReviewCounts() {
         if (reviewCount > 1) {
-            averageRating = ((averageRating * reviewCount) - oldRating) / (reviewCount - 1)
             reviewCount--
         } else {
             averageRating = 0.0
             reviewCount = 0
+        }
+    }
+
+    fun processPlaceStats(
+        currentReviewRate: Double,
+        reviewRate: Double,
+    ) {
+        if (reviewCount > 0) {
+            averageRating =
+                ((averageRating * reviewCount) - currentReviewRate + reviewRate) / reviewCount
         }
     }
 

--- a/src/main/kotlin/kr/wooco/woocobe/place/domain/model/Place.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/domain/model/Place.kt
@@ -17,9 +17,6 @@ class Place(
     fun decreaseReviewCounts() {
         if (reviewCount > 1) {
             reviewCount--
-        } else {
-            averageRating = 0.0
-            reviewCount = 0
         }
     }
 
@@ -30,6 +27,9 @@ class Place(
         if (reviewCount > 0) {
             averageRating =
                 ((averageRating * reviewCount) - currentReviewRate + reviewRate) / reviewCount
+        } else {
+            averageRating = 0.0
+            reviewCount = 0
         }
     }
 

--- a/src/main/kotlin/kr/wooco/woocobe/place/domain/usecase/AddPlaceReviewUseCase.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/domain/usecase/AddPlaceReviewUseCase.kt
@@ -35,7 +35,7 @@ class AddPlaceReviewUseCase(
                 imageUrls = input.imageUrls,
             ).also(placeReviewStorageGateway::save)
 
-        place.increaseStats(input.rating)
+        place.increasePlaceStats(input.rating)
         placeStorageGateway.save(place)
     }
 }

--- a/src/main/kotlin/kr/wooco/woocobe/place/domain/usecase/AddPlaceReviewUseCase.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/domain/usecase/AddPlaceReviewUseCase.kt
@@ -35,7 +35,8 @@ class AddPlaceReviewUseCase(
         )
         placeReviewStorageGateway.save(placeReview)
 
-        place.increasePlaceStats(input.rating)
+        place.increaseReviewCounts()
+        place.processPlaceStats(currentReviewRate = 0.0, reviewRate = input.rating)
         placeStorageGateway.save(place)
     }
 }

--- a/src/main/kotlin/kr/wooco/woocobe/place/domain/usecase/AddPlaceReviewUseCase.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/domain/usecase/AddPlaceReviewUseCase.kt
@@ -35,7 +35,7 @@ class AddPlaceReviewUseCase(
                 imageUrls = input.imageUrls,
             ).also(placeReviewStorageGateway::save)
 
-        place.addReview(input.rating)
+        place.increaseStats(input.rating)
         placeStorageGateway.save(place)
     }
 }

--- a/src/main/kotlin/kr/wooco/woocobe/place/domain/usecase/AddPlaceReviewUseCase.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/domain/usecase/AddPlaceReviewUseCase.kt
@@ -25,7 +25,7 @@ class AddPlaceReviewUseCase(
     override fun execute(input: AddPlaceReviewInput) {
         val place = placeStorageGateway.getByPlaceId(input.placeId)
 
-        PlaceReview
+        val placeReview = PlaceReview
             .register(
                 userId = input.userId,
                 placeId = place.id,
@@ -33,7 +33,8 @@ class AddPlaceReviewUseCase(
                 content = input.content,
                 oneLineReview = input.oneLineReviews,
                 imageUrls = input.imageUrls,
-            ).also(placeReviewStorageGateway::save)
+            )
+        placeReviewStorageGateway.save(placeReview)
 
         place.increasePlaceStats(input.rating)
         placeStorageGateway.save(place)

--- a/src/main/kotlin/kr/wooco/woocobe/place/domain/usecase/AddPlaceReviewUseCase.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/domain/usecase/AddPlaceReviewUseCase.kt
@@ -25,15 +25,14 @@ class AddPlaceReviewUseCase(
     override fun execute(input: AddPlaceReviewInput) {
         val place = placeStorageGateway.getByPlaceId(input.placeId)
 
-        val placeReview = PlaceReview
-            .register(
-                userId = input.userId,
-                placeId = place.id,
-                rating = input.rating,
-                content = input.content,
-                oneLineReview = input.oneLineReviews,
-                imageUrls = input.imageUrls,
-            )
+        val placeReview = PlaceReview.register(
+            userId = input.userId,
+            placeId = place.id,
+            rating = input.rating,
+            content = input.content,
+            oneLineReview = input.oneLineReviews,
+            imageUrls = input.imageUrls,
+        )
         placeReviewStorageGateway.save(placeReview)
 
         place.increasePlaceStats(input.rating)

--- a/src/main/kotlin/kr/wooco/woocobe/place/domain/usecase/AddPlaceUseCase.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/domain/usecase/AddPlaceUseCase.kt
@@ -24,7 +24,7 @@ class AddPlaceUseCase(
 ) : UseCase<AddPlaceUseCaseInput, AddPlaceUseCaseOutput> {
     @Transactional
     override fun execute(input: AddPlaceUseCaseInput): AddPlaceUseCaseOutput {
-        val existingPlace = placeStorageGateway.getByKakaoMapPlaceIdOrNull(input.kakaoMapPlaceId)
+        val existingPlace = placeStorageGateway.getOrNullByKakaoMapPlaceId(input.kakaoMapPlaceId)
 
         if (existingPlace != null) {
             return AddPlaceUseCaseOutput(placeId = existingPlace.id)

--- a/src/main/kotlin/kr/wooco/woocobe/place/domain/usecase/AddPlaceUseCase.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/domain/usecase/AddPlaceUseCase.kt
@@ -30,15 +30,16 @@ class AddPlaceUseCase(
             return AddPlaceUseCaseOutput(placeId = existingPlace.id)
         }
 
-        val newPlace = Place
+        val place = Place
             .register(
                 name = input.name,
                 latitude = input.latitude,
                 longitude = input.longitude,
                 address = input.address,
                 kakaoMapPlaceId = input.kakaoMapPlaceId,
-            ).also(placeStorageGateway::save)
+            )
+        placeStorageGateway.save(place)
 
-        return AddPlaceUseCaseOutput(placeId = newPlace.id)
+        return AddPlaceUseCaseOutput(placeId = place.id)
     }
 }

--- a/src/main/kotlin/kr/wooco/woocobe/place/domain/usecase/AddPlaceUseCase.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/domain/usecase/AddPlaceUseCase.kt
@@ -24,7 +24,7 @@ class AddPlaceUseCase(
 ) : UseCase<AddPlaceUseCaseInput, AddPlaceUseCaseOutput> {
     @Transactional
     override fun execute(input: AddPlaceUseCaseInput): AddPlaceUseCaseOutput {
-        val existingPlace = placeStorageGateway.getByKakaoMapPlaceId(input.kakaoMapPlaceId)
+        val existingPlace = placeStorageGateway.getByKakaoMapPlaceIdOrNull(input.kakaoMapPlaceId)
 
         if (existingPlace != null) {
             return AddPlaceUseCaseOutput(placeId = existingPlace.id)

--- a/src/main/kotlin/kr/wooco/woocobe/place/domain/usecase/AddPlaceUseCase.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/domain/usecase/AddPlaceUseCase.kt
@@ -30,14 +30,13 @@ class AddPlaceUseCase(
             return AddPlaceUseCaseOutput(placeId = existingPlace.id)
         }
 
-        val place = Place
-            .register(
-                name = input.name,
-                latitude = input.latitude,
-                longitude = input.longitude,
-                address = input.address,
-                kakaoMapPlaceId = input.kakaoMapPlaceId,
-            )
+        val place = Place.register(
+            name = input.name,
+            latitude = input.latitude,
+            longitude = input.longitude,
+            address = input.address,
+            kakaoMapPlaceId = input.kakaoMapPlaceId,
+        )
         placeStorageGateway.save(place)
 
         return AddPlaceUseCaseOutput(placeId = place.id)

--- a/src/main/kotlin/kr/wooco/woocobe/place/domain/usecase/DeletePlaceReviewUseCase.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/domain/usecase/DeletePlaceReviewUseCase.kt
@@ -23,7 +23,8 @@ class DeletePlaceReviewUseCase(
         placeReviewStorageGateway.deleteByPlaceReviewId(placeReviewId = placeReview.id)
 
         val place = placeStorageGateway.getByPlaceId(placeReview.placeId)
-        place.decreasePlaceStats(oldRating = placeReview.rating)
+        place.decreaseReviewCounts()
+        place.processPlaceStats(currentReviewRate = placeReview.rating, reviewRate = 0.0)
         placeStorageGateway.save(place)
     }
 }

--- a/src/main/kotlin/kr/wooco/woocobe/place/domain/usecase/DeletePlaceReviewUseCase.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/domain/usecase/DeletePlaceReviewUseCase.kt
@@ -23,7 +23,7 @@ class DeletePlaceReviewUseCase(
         placeReviewStorageGateway.deleteByPlaceReviewId(placeReviewId = placeReview.id)
 
         val place = placeStorageGateway.getByPlaceId(placeReview.placeId)
-        place.decreaseStats(oldRating = placeReview.rating)
+        place.decreasePlaceStats(oldRating = placeReview.rating)
         placeStorageGateway.save(place)
     }
 }

--- a/src/main/kotlin/kr/wooco/woocobe/place/domain/usecase/DeletePlaceReviewUseCase.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/domain/usecase/DeletePlaceReviewUseCase.kt
@@ -23,7 +23,7 @@ class DeletePlaceReviewUseCase(
         placeReviewStorageGateway.deleteByPlaceReviewId(placeReviewId = placeReview.id)
 
         val place = placeStorageGateway.getByPlaceId(placeReview.placeId)
-        place.deleteReview(oldRating = placeReview.rating)
+        place.decreaseStats(oldRating = placeReview.rating)
         placeStorageGateway.save(place)
     }
 }

--- a/src/main/kotlin/kr/wooco/woocobe/place/domain/usecase/UpdatePlaceReviewUseCase.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/domain/usecase/UpdatePlaceReviewUseCase.kt
@@ -35,8 +35,8 @@ class UpdatePlaceReviewUseCase(
 
         val place = placeStorageGateway.getByPlaceId(placeReview.placeId)
         place.processPlaceStats(
-            oldRating = placeReview.rating,
-            newRating = input.rating,
+            currentReviewRate = placeReview.rating,
+            reviewRate = input.rating,
         )
         placeStorageGateway.save(place)
     }

--- a/src/main/kotlin/kr/wooco/woocobe/place/domain/usecase/UpdatePlaceReviewUseCase.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/domain/usecase/UpdatePlaceReviewUseCase.kt
@@ -35,7 +35,7 @@ class UpdatePlaceReviewUseCase(
 
         val place = placeStorageGateway.getByPlaceId(placeReview.placeId)
 
-        place.updateReview(oldRating = placeReview.rating, newRating = input.rating)
+        place.updateStats(oldRating = placeReview.rating, newRating = input.rating)
         placeStorageGateway.save(place)
     }
 }

--- a/src/main/kotlin/kr/wooco/woocobe/place/domain/usecase/UpdatePlaceReviewUseCase.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/domain/usecase/UpdatePlaceReviewUseCase.kt
@@ -25,17 +25,19 @@ class UpdatePlaceReviewUseCase(
         val placeReview = placeReviewStorageGateway.getByPlaceReviewId(input.placeReviewId)
         placeReview.isValidWriter(input.userId)
 
-        placeReview
-            .update(
-                rating = input.rating,
-                content = input.content,
-                oneLineReviews = input.oneLineReviews,
-                imageUrls = input.imageUrls,
-            ).also(placeReviewStorageGateway::save)
+        placeReview.update(
+            rating = input.rating,
+            content = input.content,
+            oneLineReviews = input.oneLineReviews,
+            imageUrls = input.imageUrls,
+        )
+        placeReviewStorageGateway.save(placeReview)
 
         val place = placeStorageGateway.getByPlaceId(placeReview.placeId)
-
-        place.processPlaceStats(oldRating = placeReview.rating, newRating = input.rating)
+        place.processPlaceStats(
+            oldRating = placeReview.rating,
+            newRating = input.rating,
+        )
         placeStorageGateway.save(place)
     }
 }

--- a/src/main/kotlin/kr/wooco/woocobe/place/domain/usecase/UpdatePlaceReviewUseCase.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/domain/usecase/UpdatePlaceReviewUseCase.kt
@@ -35,7 +35,7 @@ class UpdatePlaceReviewUseCase(
 
         val place = placeStorageGateway.getByPlaceId(placeReview.placeId)
 
-        place.updateStats(oldRating = placeReview.rating, newRating = input.rating)
+        place.processPlaceStats(oldRating = placeReview.rating, newRating = input.rating)
         placeStorageGateway.save(place)
     }
 }

--- a/src/main/kotlin/kr/wooco/woocobe/place/infrastructure/gateway/PlaceReviewStorageGatewayImpl.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/infrastructure/gateway/PlaceReviewStorageGatewayImpl.kt
@@ -26,14 +26,12 @@ class PlaceReviewStorageGatewayImpl(
 
         val existingOneLineReviews =
             placeOneLineReviewJpaRepository.findAllByPlaceReviewId(placeReviewEntity.id!!)
-
         val newOneLineReviews = placeReview.oneLineReviews.filter { newReview ->
             existingOneLineReviews.none { it.content == newReview.content }
         }
         val removedOneLineReviews = existingOneLineReviews.filter { existingReview ->
             placeReview.oneLineReviews.none { it.content == existingReview.content }
         }
-
         placeOneLineReviewJpaRepository.deleteAll(removedOneLineReviews)
 
         val placeOneLineEntities = placeOneLineReviewJpaRepository.saveAll(
@@ -44,7 +42,6 @@ class PlaceReviewStorageGatewayImpl(
                 )
             },
         )
-
         val placeReviewImageEntities = placeReview.imageUrls.map {
             PlaceReviewImageJpaEntity(
                 placeReviewId = placeReviewEntity.id!!,
@@ -62,12 +59,10 @@ class PlaceReviewStorageGatewayImpl(
     override fun getByPlaceReviewId(placeReviewId: Long): PlaceReview {
         val placeReviewEntity = placeReviewJpaRepository.findByIdOrNull(placeReviewId)
             ?: throw RuntimeException()
-
         val oneLineReviewJpaEntities = placeOneLineReviewJpaRepository
             .findAllByPlaceReviewIdOrderByCreatedAt(placeReviewEntity.id!!)
-
-        val placeReviewImageEntities =
-            placeReviewImageJpaRepository.findAllByPlaceReviewId(placeReviewEntity.id!!)
+        val placeReviewImageEntities = placeReviewImageJpaRepository
+            .findAllByPlaceReviewId(placeReviewEntity.id!!)
 
         return placeReviewStorageMapper.toDomain(
             placeReviewEntity,
@@ -79,10 +74,8 @@ class PlaceReviewStorageGatewayImpl(
     override fun getAllByPlaceReviewIds(placeReviewIds: List<Long>): List<PlaceReview> {
         val placeReviewEntities = placeReviewJpaRepository
             .findAllByIdInOrderByCreatedAt(placeReviewIds)
-
         val placeOneLineReviewEntities = placeOneLineReviewJpaRepository
             .findAllByPlaceReviewIdInOrderByCreatedAt(placeReviewEntities.map { it.id!! })
-
         val placeReviewImageEntities = placeReviewImageJpaRepository
             .findAllByPlaceReviewIdIn(placeReviewEntities.map { it.id!! })
 
@@ -99,10 +92,8 @@ class PlaceReviewStorageGatewayImpl(
 
     override fun getAllByPlaceId(placeId: Long): List<PlaceReview> {
         val placeReviewEntities = placeReviewJpaRepository.findAllByPlaceIdOrderByCreatedAt(placeId)
-
         val placeOnLineReviewEntities = placeOneLineReviewJpaRepository
             .findAllByPlaceReviewIdInOrderByCreatedAt(placeReviewEntities.map { it.id!! })
-
         val placeReviewImageEntities = placeReviewImageJpaRepository
             .findAllByPlaceReviewIdIn(placeReviewEntities.map { it.id!! })
 
@@ -119,15 +110,12 @@ class PlaceReviewStorageGatewayImpl(
 
     override fun getAllByUserId(userId: Long): List<PlaceReview> {
         val placeReviewEntities = placeReviewJpaRepository.findAllByUserIdOrderByCreatedAt(userId)
-
         val placeOneLineReviewEntity = placeOneLineReviewJpaRepository
             .findAllByPlaceReviewIdInOrderByCreatedAt(placeReviewEntities.map { it.id!! })
-
         val placeReviewImageEntities = placeReviewImageJpaRepository
             .findAllByPlaceReviewIdIn(placeReviewEntities.map { it.id!! })
 
         return placeReviewEntities.map { placeReviewEntity ->
-
             placeReviewStorageMapper.toDomain(
                 placeReviewJpaEntity = placeReviewEntity,
                 placeOneLineReviewJpaEntities = placeOneLineReviewEntity

--- a/src/main/kotlin/kr/wooco/woocobe/place/infrastructure/gateway/PlaceReviewStorageGatewayImpl.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/infrastructure/gateway/PlaceReviewStorageGatewayImpl.kt
@@ -25,7 +25,7 @@ class PlaceReviewStorageGatewayImpl(
         placeReviewJpaRepository.save(placeReviewEntity)
 
         val existingOneLineReviews =
-            placeOneLineReviewJpaRepository.findAllByPlaceReviewId(placeReviewEntity.id!!)
+            placeOneLineReviewJpaRepository.findAllByPlaceReviewId(placeReviewEntity.id)
         val newOneLineReviews = placeReview.oneLineReviews.filter { newReview ->
             existingOneLineReviews.none { it.content == newReview.content }
         }
@@ -44,7 +44,7 @@ class PlaceReviewStorageGatewayImpl(
         )
         val placeReviewImageEntities = placeReview.imageUrls.map {
             PlaceReviewImageJpaEntity(
-                placeReviewId = placeReviewEntity.id!!,
+                placeReviewId = placeReviewEntity.id,
                 imageUrl = it,
             )
         }
@@ -60,9 +60,9 @@ class PlaceReviewStorageGatewayImpl(
         val placeReviewEntity = placeReviewJpaRepository.findByIdOrNull(placeReviewId)
             ?: throw RuntimeException()
         val oneLineReviewJpaEntities = placeOneLineReviewJpaRepository
-            .findAllByPlaceReviewIdOrderByCreatedAt(placeReviewEntity.id!!)
+            .findAllByPlaceReviewIdOrderByCreatedAt(placeReviewEntity.id)
         val placeReviewImageEntities = placeReviewImageJpaRepository
-            .findAllByPlaceReviewId(placeReviewEntity.id!!)
+            .findAllByPlaceReviewId(placeReviewEntity.id)
 
         return placeReviewStorageMapper.toDomain(
             placeReviewEntity,
@@ -75,17 +75,17 @@ class PlaceReviewStorageGatewayImpl(
         val placeReviewEntities = placeReviewJpaRepository
             .findAllByIdInOrderByCreatedAt(placeReviewIds)
         val placeOneLineReviewEntities = placeOneLineReviewJpaRepository
-            .findAllByPlaceReviewIdInOrderByCreatedAt(placeReviewEntities.map { it.id!! })
+            .findAllByPlaceReviewIdInOrderByCreatedAt(placeReviewEntities.map { it.id })
         val placeReviewImageEntities = placeReviewImageJpaRepository
-            .findAllByPlaceReviewIdIn(placeReviewEntities.map { it.id!! })
+            .findAllByPlaceReviewIdIn(placeReviewEntities.map { it.id })
 
         return placeReviewEntities.map { placeReviewEntity ->
             placeReviewStorageMapper.toDomain(
                 placeReviewJpaEntity = placeReviewEntity,
                 placeOneLineReviewJpaEntities = placeOneLineReviewEntities
-                    .filter { it.placeReviewId == placeReviewEntity.id!! },
+                    .filter { it.placeReviewId == placeReviewEntity.id },
                 placeReviewImageJpaEntities = placeReviewImageEntities
-                    .filter { it.placeReviewId == placeReviewEntity.id!! },
+                    .filter { it.placeReviewId == placeReviewEntity.id },
             )
         }
     }
@@ -93,17 +93,17 @@ class PlaceReviewStorageGatewayImpl(
     override fun getAllByPlaceId(placeId: Long): List<PlaceReview> {
         val placeReviewEntities = placeReviewJpaRepository.findAllByPlaceIdOrderByCreatedAt(placeId)
         val placeOnLineReviewEntities = placeOneLineReviewJpaRepository
-            .findAllByPlaceReviewIdInOrderByCreatedAt(placeReviewEntities.map { it.id!! })
+            .findAllByPlaceReviewIdInOrderByCreatedAt(placeReviewEntities.map { it.id })
         val placeReviewImageEntities = placeReviewImageJpaRepository
-            .findAllByPlaceReviewIdIn(placeReviewEntities.map { it.id!! })
+            .findAllByPlaceReviewIdIn(placeReviewEntities.map { it.id })
 
         return placeReviewEntities.map { placeReviewEntity ->
             placeReviewStorageMapper.toDomain(
                 placeReviewJpaEntity = placeReviewEntity,
                 placeOneLineReviewJpaEntities = placeOnLineReviewEntities
-                    .filter { it.placeReviewId == placeReviewEntity.id!! },
+                    .filter { it.placeReviewId == placeReviewEntity.id },
                 placeReviewImageJpaEntities = placeReviewImageEntities
-                    .filter { it.placeReviewId == placeReviewEntity.id!! },
+                    .filter { it.placeReviewId == placeReviewEntity.id },
             )
         }
     }
@@ -111,17 +111,17 @@ class PlaceReviewStorageGatewayImpl(
     override fun getAllByUserId(userId: Long): List<PlaceReview> {
         val placeReviewEntities = placeReviewJpaRepository.findAllByUserIdOrderByCreatedAt(userId)
         val placeOneLineReviewEntity = placeOneLineReviewJpaRepository
-            .findAllByPlaceReviewIdInOrderByCreatedAt(placeReviewEntities.map { it.id!! })
+            .findAllByPlaceReviewIdInOrderByCreatedAt(placeReviewEntities.map { it.id })
         val placeReviewImageEntities = placeReviewImageJpaRepository
-            .findAllByPlaceReviewIdIn(placeReviewEntities.map { it.id!! })
+            .findAllByPlaceReviewIdIn(placeReviewEntities.map { it.id })
 
         return placeReviewEntities.map { placeReviewEntity ->
             placeReviewStorageMapper.toDomain(
                 placeReviewJpaEntity = placeReviewEntity,
                 placeOneLineReviewJpaEntities = placeOneLineReviewEntity
-                    .filter { it.placeReviewId == placeReviewEntity.id!! },
+                    .filter { it.placeReviewId == placeReviewEntity.id },
                 placeReviewImageJpaEntities = placeReviewImageEntities
-                    .filter { it.placeReviewId == placeReviewEntity.id!! },
+                    .filter { it.placeReviewId == placeReviewEntity.id },
             )
         }
     }

--- a/src/main/kotlin/kr/wooco/woocobe/place/infrastructure/gateway/PlaceStorageGatewayImpl.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/infrastructure/gateway/PlaceStorageGatewayImpl.kt
@@ -45,6 +45,7 @@ class PlaceStorageGatewayImpl(
 
     override fun getOneLineReviewStats(placeId: Long): List<PlaceOneLineReviewStat> {
         val stats = placeOneLineReviewRepository.findPlaceOneLineReviewStatsByPlaceId(placeId)
+
         return stats.map { row ->
             val content = row[CONTENT] ?: throw RuntimeException()
             val count = row[COUNT] ?: throw RuntimeException()

--- a/src/main/kotlin/kr/wooco/woocobe/place/infrastructure/gateway/PlaceStorageGatewayImpl.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/infrastructure/gateway/PlaceStorageGatewayImpl.kt
@@ -31,7 +31,7 @@ class PlaceStorageGatewayImpl(
         return placeStorageMapper.toDomain(placeEntity)
     }
 
-    override fun getByKakaoMapPlaceIdOrNull(kakaoMapPlaceId: String): Place? {
+    override fun getOrNullByKakaoMapPlaceId(kakaoMapPlaceId: String): Place? {
         val placeEntity = placeJpaRepository.findByKakaoMapPlaceId(kakaoMapPlaceId)
 
         return placeEntity?.let { placeStorageMapper.toDomain(it) }

--- a/src/main/kotlin/kr/wooco/woocobe/place/infrastructure/gateway/PlaceStorageGatewayImpl.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/infrastructure/gateway/PlaceStorageGatewayImpl.kt
@@ -31,7 +31,7 @@ class PlaceStorageGatewayImpl(
         return placeStorageMapper.toDomain(placeEntity)
     }
 
-    override fun getByKakaoMapPlaceId(kakaoMapPlaceId: String): Place? {
+    override fun getByKakaoMapPlaceIdOrNull(kakaoMapPlaceId: String): Place? {
         val placeEntity = placeJpaRepository.findByKakaoMapPlaceId(kakaoMapPlaceId)
 
         return placeEntity?.let { placeStorageMapper.toDomain(it) }

--- a/src/main/kotlin/kr/wooco/woocobe/place/infrastructure/storage/PlaceReviewStorageMapper.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/infrastructure/storage/PlaceReviewStorageMapper.kt
@@ -15,7 +15,7 @@ class PlaceReviewStorageMapper {
         placeReviewImageJpaEntities: List<PlaceReviewImageJpaEntity>,
     ): PlaceReview =
         PlaceReview(
-            id = placeReviewJpaEntity.id!!,
+            id = placeReviewJpaEntity.id,
             userId = placeReviewJpaEntity.userId,
             placeId = placeReviewJpaEntity.placeId,
             rating = placeReviewJpaEntity.rating,

--- a/src/main/kotlin/kr/wooco/woocobe/place/infrastructure/storage/PlaceStorageMapper.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/infrastructure/storage/PlaceStorageMapper.kt
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Component
 class PlaceStorageMapper {
     fun toDomain(placeJpaEntity: PlaceJpaEntity): Place =
         Place(
-            id = placeJpaEntity.id!!,
+            id = placeJpaEntity.id,
             name = placeJpaEntity.name,
             latitude = placeJpaEntity.latitude,
             longitude = placeJpaEntity.longitude,

--- a/src/main/kotlin/kr/wooco/woocobe/place/infrastructure/storage/entity/PlaceJpaEntity.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/infrastructure/storage/entity/PlaceJpaEntity.kt
@@ -1,11 +1,11 @@
 package kr.wooco.woocobe.place.infrastructure.storage.entity
 
-import io.hypersistence.utils.hibernate.id.Tsid
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.Id
 import jakarta.persistence.Table
-import kr.wooco.woocobe.common.infrastructure.storage.BaseTimeEntity
+import kr.wooco.woocobe.common.infrastructure.storage.Tsid
+import kr.wooco.woocobe.common.infrastructure.storage.entity.BaseTimeEntity
 
 @Entity
 @Table(name = "places")
@@ -26,5 +26,5 @@ class PlaceJpaEntity(
     val name: String,
     @Id @Tsid
     @Column(name = "place_id", nullable = false)
-    val id: Long? = 0L,
+    override val id: Long = 0L,
 ) : BaseTimeEntity()

--- a/src/main/kotlin/kr/wooco/woocobe/place/infrastructure/storage/entity/PlaceOneLineReviewJpaEntity.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/infrastructure/storage/entity/PlaceOneLineReviewJpaEntity.kt
@@ -1,11 +1,11 @@
 package kr.wooco.woocobe.place.infrastructure.storage.entity
 
-import io.hypersistence.utils.hibernate.id.Tsid
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.Id
 import jakarta.persistence.Table
-import kr.wooco.woocobe.common.infrastructure.storage.BaseTimeEntity
+import kr.wooco.woocobe.common.infrastructure.storage.Tsid
+import kr.wooco.woocobe.common.infrastructure.storage.entity.BaseTimeEntity
 
 @Entity
 @Table(name = "place_one_line_reviews")
@@ -18,5 +18,5 @@ class PlaceOneLineReviewJpaEntity(
     val placeId: Long,
     @Id @Tsid
     @Column(name = "place_one_line_review_id")
-    val id: Long? = 0L,
+    override val id: Long = 0L,
 ) : BaseTimeEntity()

--- a/src/main/kotlin/kr/wooco/woocobe/place/infrastructure/storage/entity/PlaceReviewImageJpaEntity.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/infrastructure/storage/entity/PlaceReviewImageJpaEntity.kt
@@ -1,10 +1,11 @@
 package kr.wooco.woocobe.place.infrastructure.storage.entity
 
-import io.hypersistence.utils.hibernate.id.Tsid
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.Id
 import jakarta.persistence.Table
+import kr.wooco.woocobe.common.infrastructure.storage.Tsid
+import kr.wooco.woocobe.common.infrastructure.storage.entity.BaseTimeEntity
 
 @Entity
 @Table(name = "place_review_images")
@@ -15,5 +16,5 @@ class PlaceReviewImageJpaEntity(
     val placeReviewId: Long,
     @Id @Tsid
     @Column(name = "place_review_images_id")
-    val id: Long? = 0L,
-)
+    override val id: Long = 0L,
+) : BaseTimeEntity()

--- a/src/main/kotlin/kr/wooco/woocobe/place/infrastructure/storage/entity/PlaceReviewJpaEntity.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/infrastructure/storage/entity/PlaceReviewJpaEntity.kt
@@ -1,14 +1,11 @@
 package kr.wooco.woocobe.place.infrastructure.storage.entity
 
-import io.hypersistence.utils.hibernate.id.Tsid
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.Id
 import jakarta.persistence.Table
-import kr.wooco.woocobe.common.infrastructure.storage.BaseTimeEntity
-import kr.wooco.woocobe.place.domain.model.Place
-import kr.wooco.woocobe.place.domain.model.PlaceOneLineReview
-import kr.wooco.woocobe.place.domain.model.PlaceReview
+import kr.wooco.woocobe.common.infrastructure.storage.Tsid
+import kr.wooco.woocobe.common.infrastructure.storage.entity.BaseTimeEntity
 
 @Entity
 @Table(name = "place_reviews")
@@ -23,34 +20,5 @@ class PlaceReviewJpaEntity(
     val placeId: Long,
     @Id @Tsid
     @Column(name = "place_review_id", nullable = false)
-    val id: Long? = 0L,
-) : BaseTimeEntity() {
-    fun toDomain(
-        place: Place,
-        placeOneLineReview: List<PlaceOneLineReview> = emptyList(),
-        imageUrls: List<String> = emptyList(),
-    ): PlaceReview =
-        PlaceReview(
-            id = id!!,
-            userId = userId,
-            placeId = place.id,
-            writeDateTime = createdAt,
-            rating = rating,
-            content = content,
-            oneLineReviews = placeOneLineReview.map { PlaceOneLineReview.from(it.content) },
-            imageUrls = imageUrls,
-        )
-
-    companion object {
-        fun from(placeReview: PlaceReview): PlaceReviewJpaEntity =
-            with(placeReview) {
-                PlaceReviewJpaEntity(
-                    id = id,
-                    userId = userId,
-                    placeId = placeId,
-                    content = content,
-                    rating = rating,
-                )
-            }
-    }
-}
+    override val id: Long = 0L,
+) : BaseTimeEntity()


### PR DESCRIPTION
## 📝 개요

<!-- 이 PR의 목적과 관련된 정보를 간략히 설명합니다. -->

- 장소와 관련된 주요 메서드들의 네이밍을 개선하고, 코드 스타일을 정리

## ✨ 변경 사항

<!-- 코드나 기능의 주요 변경 사항을 설명 -->

1. **Place 관련 메서드 네이밍 변경**  
   - `addReview` → `increasePlaceStats`
   - `updateReview` → `processPlaceStats`
   - `deleteReview` → `decreasePlaceStats`
   - `getByKakaoMapPlaceId` → `getByKakaoMapPlaceIdOrNull`

2. **로직 리팩토링**  
   - Place 관련 로직에서 변수 선언 및 저장 로직 분리.

3. **불필요한 공백 및 스타일 정리**  
   - 코드 포맷을 통일하고 불필요한 공백 제거.

## 🔗 관련 이슈

- closed #79

## ℹ️ 참고 사항

1. **`increasePlaceStats`, `processPlaceStats`, `decreasePlaceStats` 네이밍의 이유**  
- **장소(Place)의 상태 변경을 강조:**  
   - 리뷰 작업은 장소와 연관되어 있으나, 장소 자체의 상태(averageRating, reviewCount)를 변경하는 것이 로직의 핵심입니다.  
   - `Place`를 네이밍에 포함하여 메서드가 "장소"와 관련된 상태 변경임을 직관적으로 이해할 수 있도록 했습니다.  

- 다른 의견 있으면 피드백 부탁 드립니다. 감사합니다.

