### PR TITLE
fix: JSON 안전 범위 초과시 값이 유실되는 문제 수정

### DIFF
--- a/src/main/kotlin/kr/wooco/woocobe/common/ui/config/JacksonConfig.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/common/ui/config/JacksonConfig.kt
@@ -1,13 +1,19 @@
 package kr.wooco.woocobe.common.ui.config
 
+import com.fasterxml.jackson.core.JsonGenerator
 import com.fasterxml.jackson.databind.DeserializationFeature
+import com.fasterxml.jackson.databind.JsonSerializer
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.PropertyNamingStrategies
 import com.fasterxml.jackson.databind.SerializationFeature
+import com.fasterxml.jackson.databind.SerializerProvider
+import com.fasterxml.jackson.databind.module.SimpleModule
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import kotlin.math.abs
+import kotlin.math.pow
 
 @Configuration
 class JacksonConfig {
@@ -15,8 +21,46 @@ class JacksonConfig {
     fun objectMapper(): ObjectMapper =
         jacksonObjectMapper().apply {
             propertyNamingStrategy = PropertyNamingStrategies.SNAKE_CASE
-            registerModule(JavaTimeModule())
             disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
             configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+            registerModules(JavaTimeModule(), optimizedStringSerializerModule())
         }
+
+    private fun optimizedStringSerializerModule(): SimpleModule =
+        SimpleModule().apply {
+            addSerializer(Long::class.java, OptimizedLongSerializer)
+            addSerializer(Double::class.java, OptimizedDoubleSerializer)
+        }
+
+    data object OptimizedLongSerializer : JsonSerializer<Long>() {
+        override fun serialize(
+            value: Long,
+            gen: JsonGenerator,
+            serializers: SerializerProvider,
+        ) {
+            if (abs(value) > THRESHOLD) {
+                gen.writeString(value.toString())
+            } else {
+                gen.writeNumber(value)
+            }
+        }
+    }
+
+    data object OptimizedDoubleSerializer : JsonSerializer<Double>() {
+        override fun serialize(
+            value: Double,
+            gen: JsonGenerator,
+            serializers: SerializerProvider,
+        ) {
+            if (abs(value) > THRESHOLD) {
+                gen.writeString(value.toString())
+            } else {
+                gen.writeNumber(value)
+            }
+        }
+    }
+
+    companion object {
+        private val THRESHOLD = 2.0.pow(53.0)
+    }
 }

--- a/src/main/kotlin/kr/wooco/woocobe/common/ui/config/JacksonConfig.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/common/ui/config/JacksonConfig.kt
@@ -29,26 +29,11 @@ class JacksonConfig {
     private fun optimizedStringSerializerModule(): SimpleModule =
         SimpleModule().apply {
             addSerializer(Long::class.java, OptimizedLongSerializer)
-            addSerializer(Double::class.java, OptimizedDoubleSerializer)
         }
 
     data object OptimizedLongSerializer : JsonSerializer<Long>() {
         override fun serialize(
             value: Long,
-            gen: JsonGenerator,
-            serializers: SerializerProvider,
-        ) {
-            if (abs(value) > THRESHOLD) {
-                gen.writeString(value.toString())
-            } else {
-                gen.writeNumber(value)
-            }
-        }
-    }
-
-    data object OptimizedDoubleSerializer : JsonSerializer<Double>() {
-        override fun serialize(
-            value: Double,
             gen: JsonGenerator,
             serializers: SerializerProvider,
         ) {


### PR DESCRIPTION
## 📝 개요

<!-- 이 PR의 목적과 관련된 정보를 간략히 설명합니다. -->

`Long` 또는 `Double` 값을 JSON 으로 직렬화시 값이 유실되어 0 으로 표기되던 문제를 수정합니다.

## ✨ 변경 사항

<!-- 코드나 기능의 주요 변경 사항을 설명 -->

- ✨ `Long` 값 및 `Double` 값 직렬화 로직 추가

## 🔗 관련 이슈

<!-- 이 PR과 관련된 이슈 번호를 연결 (없으면 생략) -->

- closed #103 

## ℹ️ 참고 사항

<!-- 리뷰어가 알 필요가 있는 추가 정보나 문서, 참고 링크를 포함 (없으면 생략) -->

안전 범위 밖의 값일 경우 `String` 값으로 직렬화 하도록 수정했습니다.
