### PR TITLE
refactor: 장소 도메인 예외 처리 추가 및 개선

### DIFF
--- a/src/main/kotlin/kr/wooco/woocobe/place/domain/exception/PlaceExceptions.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/domain/exception/PlaceExceptions.kt
@@ -1,0 +1,34 @@
+package kr.wooco.woocobe.place.domain.exception
+
+import kr.wooco.woocobe.common.domain.exception.CustomException
+import org.springframework.http.HttpStatus
+
+sealed class BasePlaceException(
+    code: String,
+    message: String,
+    status: HttpStatus,
+) : CustomException(code = code, message = message, status = status)
+
+data object NotExistsPlaceException : BasePlaceException(
+    code = "NOT_EXISTS_PLACE",
+    message = "존재하지 않는 장소입니다.",
+    status = HttpStatus.NOT_FOUND,
+) {
+    private fun readResolve(): Any = NotExistsPlaceException
+}
+
+data object MissingPlaceOneLineReviewContentException : BasePlaceException(
+    code = "MISSING_PLACE_ONE_LINE_REVIEW_CONTENT",
+    message = "장소 한줄평 내용이 없습니다.",
+    status = HttpStatus.BAD_REQUEST,
+) {
+    private fun readResolve(): Any = MissingPlaceOneLineReviewContentException
+}
+
+data object MissingPlaceOneLineReviewCountException : BasePlaceException(
+    code = "MISSING_PLACE_ONE_LINE_REVIEW_COUNT",
+    message = "장소 한줄평 개수가 없습니다.",
+    status = HttpStatus.BAD_REQUEST,
+) {
+    private fun readResolve(): Any = MissingPlaceOneLineReviewCountException
+}

--- a/src/main/kotlin/kr/wooco/woocobe/place/domain/exception/PlaceExceptions.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/domain/exception/PlaceExceptions.kt
@@ -17,12 +17,12 @@ data object NotExistsPlaceException : BasePlaceException(
     private fun readResolve(): Any = NotExistsPlaceException
 }
 
-data object MissingPlaceOneLineReviewContentException : BasePlaceException(
-    code = "MISSING_PLACE_ONE_LINE_REVIEW_CONTENT",
+data object MissingPlaceOneLineReviewContentsException : BasePlaceException(
+    code = "MISSING_PLACE_ONE_LINE_REVIEW_CONTENTS",
     message = "장소 한줄평 내용이 없습니다.",
     status = HttpStatus.BAD_REQUEST,
 ) {
-    private fun readResolve(): Any = MissingPlaceOneLineReviewContentException
+    private fun readResolve(): Any = MissingPlaceOneLineReviewContentsException
 }
 
 data object MissingPlaceOneLineReviewCountException : BasePlaceException(

--- a/src/main/kotlin/kr/wooco/woocobe/place/domain/exception/PlaceReviewExceptions.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/domain/exception/PlaceReviewExceptions.kt
@@ -1,0 +1,26 @@
+package kr.wooco.woocobe.place.domain.exception
+
+import kr.wooco.woocobe.common.domain.exception.CustomException
+import org.springframework.http.HttpStatus
+
+sealed class BasePlaceReviewException(
+    code: String,
+    message: String,
+    status: HttpStatus,
+) : CustomException(code = code, message = message, status = status)
+
+data object InvalidPlaceReviewWriterException : BasePlaceReviewException(
+    code = "INVALID_PLACE_REVIEW_WRITER",
+    message = "해당 장소 리뷰의 작성자가 아닙니다.",
+    status = HttpStatus.FORBIDDEN,
+) {
+    private fun readResolve(): Any = InvalidPlaceReviewWriterException
+}
+
+data object NotExistsPlaceReviewException : BasePlaceReviewException(
+    code = "NOT_EXISTS_PLACE_REVIEW",
+    message = "존재하지 않는 장소 리뷰입니다.",
+    status = HttpStatus.NOT_FOUND,
+) {
+    private fun readResolve(): Any = NotExistsPlaceReviewException
+}

--- a/src/main/kotlin/kr/wooco/woocobe/place/domain/model/Place.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/domain/model/Place.kt
@@ -32,8 +32,8 @@ class Place(
         }
     }
 
-    fun updateThumbnailUrl(imageUrl: String) {
-        thumbnailUrl = imageUrl
+    fun updateThumbnailUrl(thumbnailUrl: String) {
+        this.thumbnailUrl = thumbnailUrl
     }
 
     companion object {

--- a/src/main/kotlin/kr/wooco/woocobe/place/domain/model/PlaceOneLineReview.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/domain/model/PlaceOneLineReview.kt
@@ -1,12 +1,12 @@
 package kr.wooco.woocobe.place.domain.model
 
 class PlaceOneLineReview(
-    val content: String,
+    val contents: String,
 ) {
     companion object {
-        fun from(content: String): PlaceOneLineReview =
+        fun from(contents: String): PlaceOneLineReview =
             PlaceOneLineReview(
-                content = content,
+                contents = contents,
             )
     }
 }

--- a/src/main/kotlin/kr/wooco/woocobe/place/domain/model/PlaceOneLineReviewStat.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/domain/model/PlaceOneLineReviewStat.kt
@@ -1,6 +1,6 @@
 package kr.wooco.woocobe.place.domain.model
 
 class PlaceOneLineReviewStat(
-    val content: String,
+    val contents: String,
     val count: Long,
 )

--- a/src/main/kotlin/kr/wooco/woocobe/place/domain/model/PlaceReview.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/domain/model/PlaceReview.kt
@@ -9,18 +9,18 @@ class PlaceReview(
     val placeId: Long,
     val writeDateTime: LocalDateTime,
     var rating: Double,
-    var content: String,
+    var contents: String,
     var oneLineReviews: List<PlaceOneLineReview>,
     var imageUrls: List<String>,
 ) {
     fun update(
         rating: Double,
-        content: String,
+        contents: String,
         oneLineReviews: List<String>,
         imageUrls: List<String>,
     ) = apply {
         this.rating = rating
-        this.content = content
+        this.contents = contents
         this.oneLineReviews = oneLineReviews.map { PlaceOneLineReview.from(it) }
         this.imageUrls = imageUrls
     }
@@ -36,7 +36,7 @@ class PlaceReview(
             userId: Long,
             placeId: Long,
             rating: Double,
-            content: String,
+            contents: String,
             oneLineReview: List<String>,
             imageUrls: List<String>,
         ): PlaceReview =
@@ -46,7 +46,7 @@ class PlaceReview(
                 placeId = placeId,
                 writeDateTime = LocalDateTime.now(),
                 rating = rating,
-                content = content,
+                contents = contents,
                 oneLineReviews = oneLineReview.map { PlaceOneLineReview.from(it) },
                 imageUrls = imageUrls,
             )

--- a/src/main/kotlin/kr/wooco/woocobe/place/domain/model/PlaceReview.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/domain/model/PlaceReview.kt
@@ -1,5 +1,6 @@
 package kr.wooco.woocobe.place.domain.model
 
+import kr.wooco.woocobe.place.domain.exception.InvalidPlaceReviewWriterException
 import java.time.LocalDateTime
 
 class PlaceReview(
@@ -26,7 +27,7 @@ class PlaceReview(
 
     fun isValidWriter(userId: Long) {
         if (this.userId != userId) {
-            throw RuntimeException()
+            throw InvalidPlaceReviewWriterException
         }
     }
 

--- a/src/main/kotlin/kr/wooco/woocobe/place/domain/usecase/AddPlaceReviewUseCase.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/domain/usecase/AddPlaceReviewUseCase.kt
@@ -42,7 +42,7 @@ class AddPlaceReviewUseCase(
         )
 
         placeReview.imageUrls.firstOrNull()?.let {
-            place.updateThumbnailUrl(imageUrl = it)
+            place.updateThumbnailUrl(it)
         }
 
         place.increaseReviewCounts()

--- a/src/main/kotlin/kr/wooco/woocobe/place/domain/usecase/AddPlaceReviewUseCase.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/domain/usecase/AddPlaceReviewUseCase.kt
@@ -11,7 +11,7 @@ data class AddPlaceReviewInput(
     val userId: Long,
     val placeId: Long,
     val rating: Double,
-    val content: String,
+    val contents: String,
     val oneLineReviews: List<String>,
     val imageUrls: List<String>,
 )
@@ -35,7 +35,7 @@ class AddPlaceReviewUseCase(
                 userId = input.userId,
                 placeId = place.id,
                 rating = input.rating,
-                content = input.content,
+                contents = input.contents,
                 oneLineReview = input.oneLineReviews,
                 imageUrls = input.imageUrls,
             ),

--- a/src/main/kotlin/kr/wooco/woocobe/place/domain/usecase/UpdatePlaceReviewUseCase.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/domain/usecase/UpdatePlaceReviewUseCase.kt
@@ -10,7 +10,7 @@ data class UpdatePlaceReviewInput(
     val userId: Long,
     val placeReviewId: Long,
     val rating: Double,
-    var content: String,
+    var contents: String,
     var oneLineReviews: List<String>,
     var imageUrls: List<String>,
 )
@@ -27,7 +27,7 @@ class UpdatePlaceReviewUseCase(
 
         placeReview.update(
             rating = input.rating,
-            content = input.content,
+            contents = input.contents,
             oneLineReviews = input.oneLineReviews,
             imageUrls = input.imageUrls,
         )

--- a/src/main/kotlin/kr/wooco/woocobe/place/infrastructure/gateway/PlaceReviewStorageGatewayImpl.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/infrastructure/gateway/PlaceReviewStorageGatewayImpl.kt
@@ -28,10 +28,10 @@ internal class PlaceReviewStorageGatewayImpl(
         val existingOneLineReviews =
             placeOneLineReviewJpaRepository.findAllByPlaceReviewId(placeReviewEntity.id)
         val newOneLineReviews = placeReview.oneLineReviews.filter { newReview ->
-            existingOneLineReviews.none { it.content == newReview.content }
+            existingOneLineReviews.none { it.contents == newReview.contents }
         }
         val removedOneLineReviews = existingOneLineReviews.filter { existingReview ->
-            placeReview.oneLineReviews.none { it.content == existingReview.content }
+            placeReview.oneLineReviews.none { it.contents == existingReview.contents }
         }
         placeOneLineReviewJpaRepository.deleteAll(removedOneLineReviews)
 

--- a/src/main/kotlin/kr/wooco/woocobe/place/infrastructure/gateway/PlaceReviewStorageGatewayImpl.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/infrastructure/gateway/PlaceReviewStorageGatewayImpl.kt
@@ -1,5 +1,6 @@
 package kr.wooco.woocobe.place.infrastructure.gateway
 
+import kr.wooco.woocobe.place.domain.exception.NotExistsPlaceReviewException
 import kr.wooco.woocobe.place.domain.gateway.PlaceReviewStorageGateway
 import kr.wooco.woocobe.place.domain.model.PlaceReview
 import kr.wooco.woocobe.place.infrastructure.storage.PlaceOneLineReviewStorageMapper
@@ -58,7 +59,7 @@ class PlaceReviewStorageGatewayImpl(
 
     override fun getByPlaceReviewId(placeReviewId: Long): PlaceReview {
         val placeReviewEntity = placeReviewJpaRepository.findByIdOrNull(placeReviewId)
-            ?: throw RuntimeException()
+            ?: throw NotExistsPlaceReviewException
         val oneLineReviewJpaEntities = placeOneLineReviewJpaRepository
             .findAllByPlaceReviewIdOrderByCreatedAt(placeReviewEntity.id)
         val placeReviewImageEntities = placeReviewImageJpaRepository

--- a/src/main/kotlin/kr/wooco/woocobe/place/infrastructure/gateway/PlaceReviewStorageGatewayImpl.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/infrastructure/gateway/PlaceReviewStorageGatewayImpl.kt
@@ -14,7 +14,7 @@ import org.springframework.stereotype.Component
 
 @Component
 @Suppress("Duplicates")
-class PlaceReviewStorageGatewayImpl(
+internal class PlaceReviewStorageGatewayImpl(
     private val placeReviewJpaRepository: PlaceReviewJpaRepository,
     private val placeReviewImageJpaRepository: PlaceReviewImageJpaRepository,
     private val placeOneLineReviewJpaRepository: PlaceOneLineReviewJpaRepository,

--- a/src/main/kotlin/kr/wooco/woocobe/place/infrastructure/gateway/PlaceStorageGatewayImpl.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/infrastructure/gateway/PlaceStorageGatewayImpl.kt
@@ -14,7 +14,7 @@ import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Component
 
 @Component
-class PlaceStorageGatewayImpl(
+internal class PlaceStorageGatewayImpl(
     private val placeJpaRepository: PlaceJpaRepository,
     private val placeOneLineReviewRepository: PlaceOneLineReviewJpaRepository,
     private val placeStorageMapper: PlaceStorageMapper,

--- a/src/main/kotlin/kr/wooco/woocobe/place/infrastructure/gateway/PlaceStorageGatewayImpl.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/infrastructure/gateway/PlaceStorageGatewayImpl.kt
@@ -1,5 +1,8 @@
 package kr.wooco.woocobe.place.infrastructure.gateway
 
+import kr.wooco.woocobe.place.domain.exception.MissingPlaceOneLineReviewContentException
+import kr.wooco.woocobe.place.domain.exception.MissingPlaceOneLineReviewCountException
+import kr.wooco.woocobe.place.domain.exception.NotExistsPlaceException
 import kr.wooco.woocobe.place.domain.gateway.PlaceStorageGateway
 import kr.wooco.woocobe.place.domain.model.Place
 import kr.wooco.woocobe.place.domain.model.PlaceOneLineReviewStat
@@ -26,7 +29,7 @@ class PlaceStorageGatewayImpl(
 
     override fun getByPlaceId(placeId: Long): Place {
         val placeEntity = placeJpaRepository.findByIdOrNull(placeId)
-            ?: throw RuntimeException()
+            ?: throw NotExistsPlaceException
 
         return placeStorageMapper.toDomain(placeEntity)
     }
@@ -47,8 +50,8 @@ class PlaceStorageGatewayImpl(
         val stats = placeOneLineReviewRepository.findPlaceOneLineReviewStatsByPlaceId(placeId)
 
         return stats.map { row ->
-            val content = row[CONTENT] ?: throw RuntimeException()
-            val count = row[COUNT] ?: throw RuntimeException()
+            val content = row[CONTENT] ?: throw MissingPlaceOneLineReviewContentException
+            val count = row[COUNT] ?: throw MissingPlaceOneLineReviewCountException
 
             placeOneLineReviewStatStorageMapper.toDomain(content.toString(), count)
         }

--- a/src/main/kotlin/kr/wooco/woocobe/place/infrastructure/gateway/PlaceStorageGatewayImpl.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/infrastructure/gateway/PlaceStorageGatewayImpl.kt
@@ -1,6 +1,6 @@
 package kr.wooco.woocobe.place.infrastructure.gateway
 
-import kr.wooco.woocobe.place.domain.exception.MissingPlaceOneLineReviewContentException
+import kr.wooco.woocobe.place.domain.exception.MissingPlaceOneLineReviewContentsException
 import kr.wooco.woocobe.place.domain.exception.MissingPlaceOneLineReviewCountException
 import kr.wooco.woocobe.place.domain.exception.NotExistsPlaceException
 import kr.wooco.woocobe.place.domain.gateway.PlaceStorageGateway
@@ -50,15 +50,15 @@ internal class PlaceStorageGatewayImpl(
         val stats = placeOneLineReviewRepository.findPlaceOneLineReviewStatsByPlaceId(placeId)
 
         return stats.map { row ->
-            val content = row[CONTENT] ?: throw MissingPlaceOneLineReviewContentException
+            val contents = row[CONTENTS] ?: throw MissingPlaceOneLineReviewContentsException
             val count = row[COUNT] ?: throw MissingPlaceOneLineReviewCountException
 
-            placeOneLineReviewStatStorageMapper.toDomain(content.toString(), count)
+            placeOneLineReviewStatStorageMapper.toDomain(contents.toString(), count)
         }
     }
 
     companion object {
-        private const val CONTENT = "content"
+        private const val CONTENTS = "contents"
         private const val COUNT = "count"
     }
 }

--- a/src/main/kotlin/kr/wooco/woocobe/place/infrastructure/storage/PlaceOneLineReviewStatStorageMapper.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/infrastructure/storage/PlaceOneLineReviewStatStorageMapper.kt
@@ -6,11 +6,11 @@ import org.springframework.stereotype.Component
 @Component
 class PlaceOneLineReviewStatStorageMapper {
     fun toDomain(
-        content: String,
+        contents: String,
         count: Long,
     ): PlaceOneLineReviewStat =
         PlaceOneLineReviewStat(
-            content = content,
+            contents = contents,
             count = count,
         )
 }

--- a/src/main/kotlin/kr/wooco/woocobe/place/infrastructure/storage/PlaceOneLineReviewStorageMapper.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/infrastructure/storage/PlaceOneLineReviewStorageMapper.kt
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Component
 @Component
 class PlaceOneLineReviewStorageMapper {
     fun toDomain(placeOneLineReviewJpaEntity: PlaceOneLineReviewJpaEntity): PlaceOneLineReview =
-        PlaceOneLineReview(content = placeOneLineReviewJpaEntity.content)
+        PlaceOneLineReview(contents = placeOneLineReviewJpaEntity.contents)
 
     fun toEntity(
         placeReview: PlaceReview,
@@ -17,6 +17,6 @@ class PlaceOneLineReviewStorageMapper {
         PlaceOneLineReviewJpaEntity(
             placeId = placeReview.placeId,
             placeReviewId = placeReview.id,
-            content = placeOneLineReview.content,
+            contents = placeOneLineReview.contents,
         )
 }

--- a/src/main/kotlin/kr/wooco/woocobe/place/infrastructure/storage/PlaceReviewStorageMapper.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/infrastructure/storage/PlaceReviewStorageMapper.kt
@@ -19,9 +19,9 @@ class PlaceReviewStorageMapper {
             userId = placeReviewJpaEntity.userId,
             placeId = placeReviewJpaEntity.placeId,
             rating = placeReviewJpaEntity.rating,
-            content = placeReviewJpaEntity.content,
+            contents = placeReviewJpaEntity.contents,
             writeDateTime = placeReviewJpaEntity.createdAt,
-            oneLineReviews = placeOneLineReviewJpaEntities.map { PlaceOneLineReview(content = it.content) },
+            oneLineReviews = placeOneLineReviewJpaEntities.map { PlaceOneLineReview(contents = it.contents) },
             imageUrls = placeReviewImageJpaEntities.map { it.imageUrl },
         )
 
@@ -31,6 +31,6 @@ class PlaceReviewStorageMapper {
             userId = placeReview.userId,
             placeId = placeReview.placeId,
             rating = placeReview.rating,
-            content = placeReview.content,
+            contents = placeReview.contents,
         )
 }

--- a/src/main/kotlin/kr/wooco/woocobe/place/infrastructure/storage/entity/PlaceOneLineReviewJpaEntity.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/infrastructure/storage/entity/PlaceOneLineReviewJpaEntity.kt
@@ -10,8 +10,8 @@ import kr.wooco.woocobe.common.infrastructure.storage.entity.BaseTimeEntity
 @Entity
 @Table(name = "place_one_line_reviews")
 class PlaceOneLineReviewJpaEntity(
-    @Column(name = "content")
-    val content: String,
+    @Column(name = "contents")
+    val contents: String,
     @Column(name = "place_Review_id")
     val placeReviewId: Long,
     @Column(name = "place_id")

--- a/src/main/kotlin/kr/wooco/woocobe/place/infrastructure/storage/entity/PlaceReviewJpaEntity.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/infrastructure/storage/entity/PlaceReviewJpaEntity.kt
@@ -10,8 +10,8 @@ import kr.wooco.woocobe.common.infrastructure.storage.entity.BaseTimeEntity
 @Entity
 @Table(name = "place_reviews")
 class PlaceReviewJpaEntity(
-    @Column(name = "content", nullable = false)
-    val content: String,
+    @Column(name = "contents", nullable = false)
+    val contents: String,
     @Column(name = "rating", nullable = false)
     val rating: Double,
     @Column(name = "user_id", nullable = false)

--- a/src/main/kotlin/kr/wooco/woocobe/place/infrastructure/storage/repository/PlaceOneLineReviewJpaRepository.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/infrastructure/storage/repository/PlaceOneLineReviewJpaRepository.kt
@@ -11,10 +11,10 @@ interface PlaceOneLineReviewJpaRepository : JpaRepository<PlaceOneLineReviewJpaE
 
     @Query(
         """
-            select r.content as content, count(r.content) as count
+            select r.contents as contents, count(r.contents) as count
             from PlaceOneLineReviewJpaEntity r
             where r.placeId = :placeId
-            group by r.content
+            group by r.contents
             order by count desc
         """,
     )

--- a/src/main/kotlin/kr/wooco/woocobe/place/ui/web/controller/PlaceReviewApi.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/ui/web/controller/PlaceReviewApi.kt
@@ -21,9 +21,8 @@ interface PlaceReviewApi {
         @PathVariable placeId: Long,
     ): ResponseEntity<List<PlaceReviewDetailsResponse>>
 
-    @SecurityRequirement(name = "JWT")
     fun getAllMyPlaceReviews(
-        @AuthenticationPrincipal userId: Long,
+        @PathVariable userId: Long,
     ): ResponseEntity<List<PlaceReviewDetailsResponse>>
 
     @SecurityRequirement(name = "JWT")

--- a/src/main/kotlin/kr/wooco/woocobe/place/ui/web/controller/PlaceReviewController.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/ui/web/controller/PlaceReviewController.kt
@@ -40,9 +40,9 @@ class PlaceReviewController(
         return ResponseEntity.ok(response)
     }
 
-    @GetMapping("/my")
+    @GetMapping("/users/{userId}")
     override fun getAllMyPlaceReviews(
-        @AuthenticationPrincipal userId: Long,
+        @PathVariable userId: Long,
     ): ResponseEntity<List<PlaceReviewDetailsResponse>> {
         val response = placeReviewQueryFacade.getAllMyPlaceReview(userId)
         return ResponseEntity.ok(response)

--- a/src/main/kotlin/kr/wooco/woocobe/place/ui/web/controller/request/CreatePlaceReviewRequest.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/ui/web/controller/request/CreatePlaceReviewRequest.kt
@@ -4,7 +4,7 @@ import kr.wooco.woocobe.place.domain.usecase.AddPlaceReviewInput
 
 data class CreatePlaceReviewRequest(
     val rating: Double,
-    val content: String,
+    val contents: String,
     val oneLineReviews: List<String>,
     val imageUrls: List<String>,
 ) {
@@ -16,7 +16,7 @@ data class CreatePlaceReviewRequest(
             userId = userId,
             placeId = placeId,
             rating = rating,
-            content = content,
+            contents = contents,
             oneLineReviews = oneLineReviews,
             imageUrls = imageUrls,
         )

--- a/src/main/kotlin/kr/wooco/woocobe/place/ui/web/controller/request/UpdatePlaceReviewRequest.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/ui/web/controller/request/UpdatePlaceReviewRequest.kt
@@ -4,7 +4,7 @@ import kr.wooco.woocobe.place.domain.usecase.UpdatePlaceReviewInput
 
 data class UpdatePlaceReviewRequest(
     val rating: Double,
-    val content: String,
+    val contents: String,
     val oneLineReviews: List<String>,
     val imageUrls: List<String>,
 ) {
@@ -16,7 +16,7 @@ data class UpdatePlaceReviewRequest(
             userId = userId,
             placeReviewId = placeReviewId,
             rating = rating,
-            content = content,
+            contents = contents,
             oneLineReviews = oneLineReviews,
             imageUrls = imageUrls,
         )

--- a/src/main/kotlin/kr/wooco/woocobe/place/ui/web/controller/response/PlaceOneLineReviewStatDetailResponse.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/ui/web/controller/response/PlaceOneLineReviewStatDetailResponse.kt
@@ -3,14 +3,14 @@ package kr.wooco.woocobe.place.ui.web.controller.response
 import kr.wooco.woocobe.place.domain.model.PlaceOneLineReviewStat
 
 data class PlaceOneLineReviewStatDetailResponse(
-    val content: String,
+    val contents: String,
     val count: Long,
 ) {
     companion object {
         fun listFrom(placeOneLineReviewStat: List<PlaceOneLineReviewStat>): List<PlaceOneLineReviewStatDetailResponse> =
             placeOneLineReviewStat.map {
                 PlaceOneLineReviewStatDetailResponse(
-                    content = it.content,
+                    contents = it.contents,
                     count = it.count,
                 )
             }

--- a/src/main/kotlin/kr/wooco/woocobe/place/ui/web/controller/response/PlaceReviewDetailsResponse.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/ui/web/controller/response/PlaceReviewDetailsResponse.kt
@@ -8,7 +8,7 @@ data class PlaceReviewDetailsResponse(
     val placeReviewId: Long,
     val writer: PlaceReviewWriterResponse,
     val rating: Double,
-    val content: String,
+    val contents: String,
     val createdAt: LocalDateTime,
     val oneLineReviews: List<PlaceOneLineReviewResponse>,
     val imageUrls: List<String>,
@@ -22,11 +22,11 @@ data class PlaceReviewDetailsResponse(
                 placeReviewId = placeReview.id,
                 writer = PlaceReviewWriterResponse.from(user),
                 rating = placeReview.rating,
-                content = placeReview.content,
+                contents = placeReview.contents,
                 createdAt = placeReview.writeDateTime,
                 oneLineReviews = placeReview.oneLineReviews
                     .map { placeOneLineReview ->
-                        PlaceOneLineReviewResponse.from(placeOneLineReview.content)
+                        PlaceOneLineReviewResponse.from(placeOneLineReview.contents)
                     },
                 imageUrls = placeReview.imageUrls,
             )
@@ -44,11 +44,11 @@ data class PlaceReviewDetailsResponse(
                     placeReviewId = placeReview.id,
                     writer = PlaceReviewWriterResponse.from(writer),
                     rating = placeReview.rating,
-                    content = placeReview.content,
+                    contents = placeReview.contents,
                     createdAt = placeReview.writeDateTime,
                     oneLineReviews = placeReview.oneLineReviews
                         .map { placeOneLineReview ->
-                            PlaceOneLineReviewResponse.from(placeOneLineReview.content)
+                            PlaceOneLineReviewResponse.from(placeOneLineReview.contents)
                         },
                     imageUrls = placeReview.imageUrls,
                 )
@@ -58,12 +58,12 @@ data class PlaceReviewDetailsResponse(
 }
 
 data class PlaceOneLineReviewResponse(
-    val content: String,
+    val contents: String,
 ) {
     companion object {
         fun from(oneLineReview: String): PlaceOneLineReviewResponse =
             PlaceOneLineReviewResponse(
-                content = oneLineReview,
+                contents = oneLineReview,
             )
     }
 }

--- a/src/main/kotlin/kr/wooco/woocobe/place/ui/web/controller/response/PlaceReviewDetailsResponse.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/place/ui/web/controller/response/PlaceReviewDetailsResponse.kt
@@ -2,12 +2,14 @@ package kr.wooco.woocobe.place.ui.web.controller.response
 
 import kr.wooco.woocobe.place.domain.model.PlaceReview
 import kr.wooco.woocobe.user.domain.model.User
+import java.time.LocalDateTime
 
 data class PlaceReviewDetailsResponse(
     val placeReviewId: Long,
     val writer: PlaceReviewWriterResponse,
     val rating: Double,
     val content: String,
+    val createdAt: LocalDateTime,
     val oneLineReviews: List<PlaceOneLineReviewResponse>,
     val imageUrls: List<String>,
 ) {
@@ -21,6 +23,7 @@ data class PlaceReviewDetailsResponse(
                 writer = PlaceReviewWriterResponse.from(user),
                 rating = placeReview.rating,
                 content = placeReview.content,
+                createdAt = placeReview.writeDateTime,
                 oneLineReviews = placeReview.oneLineReviews
                     .map { placeOneLineReview ->
                         PlaceOneLineReviewResponse.from(placeOneLineReview.content)
@@ -42,6 +45,7 @@ data class PlaceReviewDetailsResponse(
                     writer = PlaceReviewWriterResponse.from(writer),
                     rating = placeReview.rating,
                     content = placeReview.content,
+                    createdAt = placeReview.writeDateTime,
                     oneLineReviews = placeReview.oneLineReviews
                         .map { placeOneLineReview ->
                             PlaceOneLineReviewResponse.from(placeOneLineReview.content)


### PR DESCRIPTION
## 📝 개요

- 장소 도메인의 예외를 정의하고, 에러 핸들링을 개선
- 회원이 작성 리뷰 리스트 API 엔드포인트 수정

## ✨ 변경 사항

1. **도메인 예외 처리 추가**  
   - **장소 관련 예외**
     - `NotExistsPlaceException`: 존재하지 않는 장소 요청 시 발생.
     - `MissingPlaceOneLineReviewContentException`: 한줄평 내용 누락 시 발생.
     - `MissingPlaceOneLineReviewCountException`: 한줄평 개수 누락 시 발생.
   - **리뷰 관련 예외**
     - `NotExistsPlaceReviewException`: 존재하지 않는 리뷰 요청 시 발생.
     - `InvalidPlaceReviewWriterException`: 리뷰 작성자가 아닌 사용자가 수정/삭제를 시도할 경우 발생.

2. **예외 적용**
   - `RuntimeException`을 도메인별 구체적인 예외 클래스로 대체.

3. **접근 제어자 수정**
   - `PlaceReviewStorageGatewayImpl` 및 `PlaceStorageGatewayImpl`의 클래스 접근 제어자를 `internal`로 변경

4. **함수 파라미터 명 수정**
   - `updateThumbnailUrl` 함수의 파라미터명을 `imageUrl` ->`thumbnailUrl`로 변경
5. **DTO 수정**
   - `PlaceReviewDetailsResponse`에 `createdAt` 누락된  필드 추가.
   
6. **API 경로 및 파라미터 수정**  
   - 경로 변경: `/my` → `/users/{userId}`
   - 메서드 파라미터 수정: `@AuthenticationPrincipal userId` → `@PathVariable userId`

## 🔗 관련 이슈

- closed #115

## ℹ️ 참고 사항