### PR TITLE
feat: 플랜 도메인 커스텀 예외 추가 및 응답 형식 통일

### DIFF
--- a/src/main/kotlin/kr/wooco/woocobe/plan/domain/exception/PlanExceptions.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/plan/domain/exception/PlanExceptions.kt
@@ -1,0 +1,34 @@
+package kr.wooco.woocobe.plan.domain.exception
+
+import kr.wooco.woocobe.common.domain.exception.CustomException
+import org.springframework.http.HttpStatus
+
+sealed class BasePlanException(
+    code: String,
+    message: String,
+    status: HttpStatus,
+) : CustomException(code = code, message = message, status = status)
+
+data object InvalidPlanWriterException : BasePlanException(
+    code = "INVALID_PLAN_WRITER",
+    message = "해당 플랜의 작성자가 아닙니다.",
+    status = HttpStatus.FORBIDDEN,
+) {
+    private fun readResolve(): Any = InvalidPlanWriterException
+}
+
+data object NotExistsPlanException : BasePlanException(
+    code = "NOT_EXISTS_PLAN",
+    message = "존재하지 않는 플랜입니다.",
+    status = HttpStatus.NOT_FOUND,
+) {
+    private fun readResolve(): Any = NotExistsPlanException
+}
+
+data object UnSupportCategoryException : BasePlanException(
+    code = "UN_SUPPORT_CATEGORY",
+    message = "지원하지 않는 카테고리 형식입니다.",
+    status = HttpStatus.BAD_REQUEST,
+) {
+    private fun readResolve(): Any = UnSupportCategoryException
+}

--- a/src/main/kotlin/kr/wooco/woocobe/plan/domain/model/Plan.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/plan/domain/model/Plan.kt
@@ -1,5 +1,6 @@
 package kr.wooco.woocobe.plan.domain.model
 
+import kr.wooco.woocobe.plan.domain.exception.InvalidPlanWriterException
 import java.time.LocalDate
 
 class Plan(
@@ -12,10 +13,8 @@ class Plan(
     var places: List<PlanPlace>,
     var categories: List<PlanCategory>,
 ) {
-    fun isWriterOrThrow(targetId: Long) {
-        if (userId != targetId) {
-            throw RuntimeException()
-        }
+    fun isWriterOrThrow(userId: Long) {
+        if (this.userId != userId) throw InvalidPlanWriterException
     }
 
     fun update(

--- a/src/main/kotlin/kr/wooco/woocobe/plan/domain/model/Plan.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/plan/domain/model/Plan.kt
@@ -6,7 +6,7 @@ class Plan(
     val id: Long,
     val userId: Long,
     var title: String,
-    var description: String,
+    var contents: String,
     var region: PlanRegion,
     var visitDate: LocalDate,
     var places: List<PlanPlace>,
@@ -20,14 +20,14 @@ class Plan(
 
     fun update(
         title: String,
-        description: String,
+        contents: String,
         region: PlanRegion,
         visitDate: LocalDate,
         placeIds: List<Long>,
         categories: List<String>,
     ) = apply {
         this.title = title
-        this.description = description
+        this.contents = contents
         this.region = region
         this.visitDate = visitDate
         this.places = processPlanPlaceOrder(placeIds)
@@ -38,7 +38,7 @@ class Plan(
         fun register(
             userId: Long,
             title: String,
-            description: String,
+            contents: String,
             region: PlanRegion,
             visitDate: LocalDate,
             categories: List<String>,
@@ -48,7 +48,7 @@ class Plan(
                 id = 0L,
                 userId = userId,
                 title = title,
-                description = description,
+                contents = contents,
                 region = region,
                 visitDate = visitDate,
                 categories = categories.map { PlanCategory.from(it) },

--- a/src/main/kotlin/kr/wooco/woocobe/plan/domain/model/PlanCategory.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/plan/domain/model/PlanCategory.kt
@@ -1,5 +1,7 @@
 package kr.wooco.woocobe.plan.domain.model
 
+import kr.wooco.woocobe.plan.domain.exception.UnSupportCategoryException
+
 enum class PlanCategory {
     FAMOUS_RESTAURANT,
     ACTIVITY,
@@ -11,6 +13,6 @@ enum class PlanCategory {
     companion object {
         fun from(viewName: String) =
             PlanCategory.entries.find { it.name == viewName }
-                ?: throw RuntimeException("not found plan category $viewName")
+                ?: throw UnSupportCategoryException
     }
 }

--- a/src/main/kotlin/kr/wooco/woocobe/plan/domain/usecase/AddPlanUseCase.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/plan/domain/usecase/AddPlanUseCase.kt
@@ -11,7 +11,7 @@ import java.time.LocalDate
 data class AddPlanInput(
     val userId: Long,
     val title: String,
-    val description: String,
+    val contents: String,
     val primaryRegion: String,
     val secondaryRegion: String,
     val visitDate: LocalDate,
@@ -38,7 +38,7 @@ class AddPlanUseCase(
             Plan.register(
                 userId = input.userId,
                 title = input.title,
-                description = input.description,
+                contents = input.contents,
                 region = region,
                 visitDate = input.visitDate,
                 placeIds = input.placeIds,

--- a/src/main/kotlin/kr/wooco/woocobe/plan/domain/usecase/UpdatePlanUseCase.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/plan/domain/usecase/UpdatePlanUseCase.kt
@@ -11,7 +11,7 @@ data class UpdatePlanInput(
     val userId: Long,
     val planId: Long,
     val title: String,
-    val description: String,
+    val contents: String,
     val primaryRegion: String,
     val secondaryRegion: String,
     val visitDate: LocalDate,
@@ -36,7 +36,7 @@ class UpdatePlanUseCase(
 
         plan.update(
             title = input.title,
-            description = input.description,
+            contents = input.contents,
             region = region,
             visitDate = input.visitDate,
             placeIds = input.placeIds,

--- a/src/main/kotlin/kr/wooco/woocobe/plan/infrastructure/gateway/PlanStorageGatewayImpl.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/plan/infrastructure/gateway/PlanStorageGatewayImpl.kt
@@ -1,5 +1,6 @@
 package kr.wooco.woocobe.plan.infrastructure.gateway
 
+import kr.wooco.woocobe.plan.domain.exception.NotExistsPlanException
 import kr.wooco.woocobe.plan.domain.gateway.PlanStorageGateway
 import kr.wooco.woocobe.plan.domain.model.Plan
 import kr.wooco.woocobe.plan.infrastructure.storage.PlanCategoryStorageMapper
@@ -36,7 +37,7 @@ internal class PlanStorageGatewayImpl(
 
     override fun getByPlanId(planId: Long): Plan {
         val planEntity = planJpaRepository.findByIdOrNull(planId)
-            ?: throw RuntimeException()
+            ?: throw NotExistsPlanException
         val planPlaceEntities = planPlaceJpaRepository.findAllByPlanId(planId)
         val planCategoryEntities = planCategoryJpaRepository.findAllByPlanId(planId)
 

--- a/src/main/kotlin/kr/wooco/woocobe/plan/infrastructure/storage/PlanStorageMapper.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/plan/infrastructure/storage/PlanStorageMapper.kt
@@ -20,7 +20,7 @@ class PlanStorageMapper {
             id = planJpaEntity.id,
             userId = planJpaEntity.userId,
             title = planJpaEntity.title,
-            description = planJpaEntity.description,
+            contents = planJpaEntity.contents,
             region = PlanRegion(
                 primaryRegion = planJpaEntity.primaryRegion,
                 secondaryRegion = planJpaEntity.secondaryRegion,
@@ -35,7 +35,7 @@ class PlanStorageMapper {
             id = plan.id,
             userId = plan.userId,
             title = plan.title,
-            description = plan.description,
+            contents = plan.contents,
             primaryRegion = plan.region.primaryRegion,
             secondaryRegion = plan.region.secondaryRegion,
             visitDate = plan.visitDate,

--- a/src/main/kotlin/kr/wooco/woocobe/plan/infrastructure/storage/entity/PlanJpaEntity.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/plan/infrastructure/storage/entity/PlanJpaEntity.kt
@@ -15,8 +15,8 @@ class PlanJpaEntity(
     val userId: Long,
     @Column(name = "title", length = 20)
     val title: String,
-    @Column(name = "description", columnDefinition = "text")
-    val description: String,
+    @Column(name = "contents", columnDefinition = "text")
+    val contents: String,
     @Column(name = "primary_region")
     val primaryRegion: String,
     @Column(name = "secondary_region")

--- a/src/main/kotlin/kr/wooco/woocobe/plan/ui/web/controller/request/CreatePlanRequest.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/plan/ui/web/controller/request/CreatePlanRequest.kt
@@ -5,7 +5,7 @@ import java.time.LocalDate
 
 data class CreatePlanRequest(
     val title: String,
-    val description: String,
+    val contents: String,
     val primaryRegion: String,
     val secondaryRegion: String,
     val visitDate: LocalDate,
@@ -16,7 +16,7 @@ data class CreatePlanRequest(
         AddPlanInput(
             userId = userId,
             title = title,
-            description = description,
+            contents = contents,
             primaryRegion = primaryRegion,
             secondaryRegion = secondaryRegion,
             visitDate = visitDate,

--- a/src/main/kotlin/kr/wooco/woocobe/plan/ui/web/controller/request/UpdatePlanRequest.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/plan/ui/web/controller/request/UpdatePlanRequest.kt
@@ -5,7 +5,7 @@ import java.time.LocalDate
 
 data class UpdatePlanRequest(
     val title: String,
-    val description: String,
+    val contents: String,
     val primaryRegion: String,
     val secondaryRegion: String,
     val visitDate: LocalDate,
@@ -20,7 +20,7 @@ data class UpdatePlanRequest(
             userId = userId,
             planId = planId,
             title = title,
-            description = description,
+            contents = contents,
             primaryRegion = primaryRegion,
             secondaryRegion = secondaryRegion,
             visitDate = visitDate,

--- a/src/main/kotlin/kr/wooco/woocobe/plan/ui/web/controller/response/PlanDetailResponse.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/plan/ui/web/controller/response/PlanDetailResponse.kt
@@ -7,7 +7,7 @@ import java.time.LocalDate
 data class PlanDetailResponse(
     val id: Long,
     val title: String,
-    val description: String,
+    val contents: String,
     val primaryRegion: String,
     val secondaryRegion: String,
     val visitDate: LocalDate,
@@ -38,7 +38,7 @@ data class PlanDetailResponse(
             PlanDetailResponse(
                 id = plan.id,
                 title = plan.title,
-                description = plan.description,
+                contents = plan.contents,
                 primaryRegion = plan.region.primaryRegion,
                 secondaryRegion = plan.region.secondaryRegion,
                 visitDate = plan.visitDate,


### PR DESCRIPTION
## 📝 개요

- 플랜 도메인 커스텀 예외를 추가 합니다.
- 플랜 도메인 API 응답 형식을 통일합니다.

## ✨ 변경 사항

- ✨ 플랜 도메인의 커스텀 예외 추가 및 적용
- ✨ 기존 `description` 필드명을 `contents`로 변경, API 응답 필드명 적용

## 🔗 관련 이슈

- closed #117 
