### PR TITLE
refactor: 관심 코스 조회시 최대 개수 지정 추가

### DIFF
--- a/src/main/kotlin/kr/wooco/woocobe/course/domain/gateway/InterestCourseStorageGateway.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/course/domain/gateway/InterestCourseStorageGateway.kt
@@ -10,7 +10,10 @@ interface InterestCourseStorageGateway {
         userId: Long,
     ): InterestCourse
 
-    fun getAllByUserId(userId: Long): List<InterestCourse>
+    fun getAllByUserId(
+        userId: Long,
+        limit: Int?,
+    ): List<InterestCourse>
 
     fun existsByCourseIdAndUserId(
         courseId: Long,

--- a/src/main/kotlin/kr/wooco/woocobe/course/domain/usecase/GetAllUserInterestCourseUseCase.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/course/domain/usecase/GetAllUserInterestCourseUseCase.kt
@@ -9,6 +9,7 @@ import org.springframework.transaction.annotation.Transactional
 
 data class GetAllUserInterestCourseInput(
     val userId: Long,
+    val limit: Int?,
 )
 
 data class GetAllUserInterestCourseOutput(
@@ -22,7 +23,7 @@ class GetAllUserInterestCourseUseCase(
 ) : UseCase<GetAllUserInterestCourseInput, GetAllUserInterestCourseOutput> {
     @Transactional(readOnly = true)
     override fun execute(input: GetAllUserInterestCourseInput): GetAllUserInterestCourseOutput {
-        val interestCourses = interestCourseStorageGateway.getAllByUserId(userId = input.userId)
+        val interestCourses = interestCourseStorageGateway.getAllByUserId(userId = input.userId, limit = input.limit)
         val courseIds = interestCourses.map { it.courseId }
         val courses = courseStorageGateway.getAllByCourseIds(courseIds)
 

--- a/src/main/kotlin/kr/wooco/woocobe/course/infrastructure/gateway/InterestCourseStorageGatewayImpl.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/course/infrastructure/gateway/InterestCourseStorageGatewayImpl.kt
@@ -5,6 +5,8 @@ import kr.wooco.woocobe.course.domain.gateway.InterestCourseStorageGateway
 import kr.wooco.woocobe.course.domain.model.InterestCourse
 import kr.wooco.woocobe.course.infrastructure.storage.InterestCourseStorageMapper
 import kr.wooco.woocobe.course.infrastructure.storage.repository.InterestCourseJpaRepository
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Component
 
 @Component
@@ -27,8 +29,12 @@ internal class InterestCourseStorageGatewayImpl(
         return interestCourseStorageMapper.toDomain(interestCourseEntity)
     }
 
-    override fun getAllByUserId(userId: Long): List<InterestCourse> {
-        val interestCourseEntities = interestCourseJpaRepository.findAllByUserId(userId = userId)
+    override fun getAllByUserId(
+        userId: Long,
+        limit: Int?,
+    ): List<InterestCourse> {
+        val pageable = limit?.let { PageRequest.of(0, it) } ?: Pageable.unpaged()
+        val interestCourseEntities = interestCourseJpaRepository.findAllByUserId(userId = userId, pageable = pageable)
         return interestCourseEntities.map { interestCourseStorageMapper.toDomain(it) }
     }
 

--- a/src/main/kotlin/kr/wooco/woocobe/course/infrastructure/storage/repository/InterestCourseJpaRepository.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/course/infrastructure/storage/repository/InterestCourseJpaRepository.kt
@@ -1,6 +1,7 @@
 package kr.wooco.woocobe.course.infrastructure.storage.repository
 
 import kr.wooco.woocobe.course.infrastructure.storage.entity.InterestCourseJpaEntity
+import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 
@@ -38,5 +39,8 @@ interface InterestCourseJpaRepository : JpaRepository<InterestCourseJpaEntity, L
         courseIds: List<Long>,
     ): List<Long>
 
-    fun findAllByUserId(userId: Long): List<InterestCourseJpaEntity>
+    fun findAllByUserId(
+        userId: Long,
+        pageable: Pageable,
+    ): List<InterestCourseJpaEntity>
 }

--- a/src/main/kotlin/kr/wooco/woocobe/course/ui/web/controller/CourseApi.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/course/ui/web/controller/CourseApi.kt
@@ -74,6 +74,7 @@ interface CourseApi {
     fun getAllUserInterestCourse(
         @AuthenticationPrincipal currentUserId: Long?,
         @PathVariable userId: Long,
+        @RequestParam(required = false) limit: Int?,
     ): ResponseEntity<List<CourseDetailResponse>>
 
     @SecurityRequirement(name = "JWT")

--- a/src/main/kotlin/kr/wooco/woocobe/course/ui/web/controller/CourseController.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/course/ui/web/controller/CourseController.kt
@@ -38,8 +38,8 @@ class CourseController(
     override fun getAllCourse(
         @AuthenticationPrincipal userId: Long?,
         @RequestParam(required = false, defaultValue = "RECENT") sort: String,
-        @RequestParam(required = false) primaryRegion: String?,
-        @RequestParam(required = false) secondaryRegion: String?,
+        @RequestParam(required = false, name = "primary_region") primaryRegion: String?,
+        @RequestParam(required = false, name = "secondary_region") secondaryRegion: String?,
         @RequestParam(required = false) category: String?,
         @RequestParam(required = false) limit: Int?,
     ): ResponseEntity<List<CourseDetailResponse>> {
@@ -69,8 +69,13 @@ class CourseController(
     override fun getAllUserInterestCourse(
         @AuthenticationPrincipal currentUserId: Long?,
         @PathVariable userId: Long,
+        @RequestParam(required = false) limit: Int?,
     ): ResponseEntity<List<CourseDetailResponse>> {
-        val response = courseQueryFacade.getAllUserInterestCourse(currentUserId = currentUserId, userId = userId)
+        val response = courseQueryFacade.getAllUserInterestCourse(
+            currentUserId = currentUserId,
+            userId = userId,
+            limit = limit,
+        )
         return ResponseEntity.ok(response)
     }
 

--- a/src/main/kotlin/kr/wooco/woocobe/course/ui/web/facade/CourseQueryFacade.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/course/ui/web/facade/CourseQueryFacade.kt
@@ -128,9 +128,10 @@ class CourseQueryFacade(
     fun getAllUserInterestCourse(
         currentUserId: Long?,
         userId: Long,
+        limit: Int?,
     ): List<CourseDetailResponse> {
         val getAllUserInterestCourseResult =
-            getAllUserInterestCourseUseCase.execute(GetAllUserInterestCourseInput(userId = userId))
+            getAllUserInterestCourseUseCase.execute(GetAllUserInterestCourseInput(userId = userId, limit = limit))
 
         val writerIds = getAllUserInterestCourseResult.courses.map { it.userId }
         val getAllUserResult = getAllUserUseCase.execute(GetAllUserInput(userIds = writerIds))


### PR DESCRIPTION
## 📝 개요

<!-- 이 PR의 목적과 관련된 정보를 간략히 설명합니다. -->

관심 코스 조회시 최대 개수를 지정할 수 있도록 수정합니다.

## ✨ 변경 사항

<!-- 코드나 기능의 주요 변경 사항을 설명 -->

- ✨ 관심 코스 조회시 `limit` 추가

## 🔗 관련 이슈

<!-- 이 PR과 관련된 이슈 번호를 연결 (없으면 생략) -->

- closed #121 

## ℹ️ 참고 사항

<!-- 리뷰어가 알 필요가 있는 추가 정보나 문서, 참고 링크를 포함 (없으면 생략) -->

- 
