### PR TITLE
fix: PlanPlaceResult 매핑 오류 수정

### DIFF
--- a/src/main/kotlin/kr/wooco/woocobe/plan/adapter/in/web/response/PlanDetailResponse.kt
+++ b/src/main/kotlin/kr/wooco/woocobe/plan/adapter/in/web/response/PlanDetailResponse.kt
@@ -1,6 +1,5 @@
 package kr.wooco.woocobe.plan.adapter.`in`.web.response
 
-import kr.wooco.woocobe.plan.application.port.`in`.results.PlanPlaceResult
 import kr.wooco.woocobe.plan.application.port.`in`.results.PlanResult
 import java.time.LocalDate
 
@@ -50,7 +49,7 @@ data class PlanPlaceResponse(
     companion object {
         fun of(
             order: Int,
-            place: PlanPlaceResult,
+            place: PlanResult.PlanPlaceResult,
         ): PlanPlaceResponse =
             PlanPlaceResponse(
                 order = order,


### PR DESCRIPTION
## 📝 개요

- `PlanDetailResponse` 의 PlanPlaceResult 매핑 오류를 해결합니다.

## ✨ 변경 사항

- ✨PlanPlaceResult 매핑 오류 해결

## 🔗 관련 이슈

- closed #152 
