### PR TITLE
feat: 댓글 생성 이벤트 발행 로직 추가

### DIFF
--- a/core/src/main/kotlin/kr/wooco/woocobe/core/coursecomment/domain/event/CourseCommentCreateEvent.kt
+++ b/core/src/main/kotlin/kr/wooco/woocobe/core/coursecomment/domain/event/CourseCommentCreateEvent.kt
@@ -1,0 +1,24 @@
+package kr.wooco.woocobe.core.coursecomment.domain.event
+
+import kr.wooco.woocobe.core.course.domain.entity.Course
+import kr.wooco.woocobe.core.coursecomment.domain.entity.CourseComment
+
+class CourseCommentCreateEvent(
+    val courseId: Long,
+    val courseWriterId: Long,
+    val courseCommentId: Long,
+    val commentWriterId: Long,
+) {
+    companion object {
+        fun of(
+            course: Course,
+            courseComment: CourseComment,
+        ): CourseCommentCreateEvent =
+            CourseCommentCreateEvent(
+                courseId = course.id,
+                courseWriterId = course.userId,
+                courseCommentId = courseComment.id,
+                commentWriterId = courseComment.userId,
+            )
+    }
+}


### PR DESCRIPTION
## 📝 개요

<!-- 이 PR의 목적과 관련된 정보를 간략히 설명합니다. -->

댓글 생성시 이벤트 발행 로직을 추가합니다.

## ✨ 변경 사항

<!-- 코드나 기능의 주요 변경 사항을 설명 -->

- ✨ 댓글 생성시 스프링 내부 이벤트 발행 로직 추가
- ✨ 댓글 생성시 코스의 댓글 개수 증가 로직 추가

## 🔗 관련 이슈

<!-- 이 PR과 관련된 이슈 번호를 연결 (없으면 생략) -->

- closed #159 

## ℹ️ 참고 사항

<!-- 리뷰어가 알 필요가 있는 추가 정보나 문서, 참고 링크를 포함 (없으면 생략) -->

현재 댓글 생성시 댓글 알림을 위해 필요한 데이터기 코스 작성자의 식별자(user_id)와 코스의 이름이 필요한 상태입니다.
일단 빠르게 구현하기 위해, 댓글 생성 유즈케이스 내에서 1. 댓글을 생성 2.해당 코스의 댓글 수 증가 3. 알림 이벤트 전송(코스 정보 + 댓글 작성자 정보) 를 발행하는 로직으로 구현되어있습니다.

구현된 부분이 SRP 위반일지 아닐지 한번더 고민 후 리팩토링 방향을 정해야할 것 같습니다.
