### PR TITLE
feat: 알림 도메인 기능 추가

### DIFF
--- a/bootstrap/api/src/main/kotlin/kr/wooco/woocobe/api/WoocoBeApplication.kt
+++ b/bootstrap/api/src/main/kotlin/kr/wooco/woocobe/api/WoocoBeApplication.kt
@@ -2,6 +2,7 @@ package kr.wooco.woocobe.api
 
 import kr.wooco.woocobe.aws.common.config.AwsConfig
 import kr.wooco.woocobe.core.common.config.CoreConfig
+import kr.wooco.woocobe.core.common.config.SchedulingConfig
 import kr.wooco.woocobe.fcm.common.config.FcmConfig
 import kr.wooco.woocobe.jwt.common.config.JwtConfig
 import kr.wooco.woocobe.mysql.common.config.MysqlConfig
@@ -21,6 +22,7 @@ import org.springframework.context.annotation.Import
         RedisConfig::class,
         RestConfig::class,
         FcmConfig::class,
+        SchedulingConfig::class,
     ],
 )
 @SpringBootApplication

--- a/bootstrap/api/src/main/kotlin/kr/wooco/woocobe/api/notification/NotificationApi.kt
+++ b/bootstrap/api/src/main/kotlin/kr/wooco/woocobe/api/notification/NotificationApi.kt
@@ -1,0 +1,36 @@
+package kr.wooco.woocobe.api.notification
+
+import io.swagger.v3.oas.annotations.security.SecurityRequirement
+import io.swagger.v3.oas.annotations.tags.Tag
+import kr.wooco.woocobe.api.notification.request.CreateDeviceTokenRequest
+import kr.wooco.woocobe.api.notification.response.NotificationDetailResponse
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestBody
+
+@Tag(name = "알림 API")
+interface NotificationApi {
+    @SecurityRequirement(name = "JWT")
+    fun getAllUserNotification(
+        @AuthenticationPrincipal userId: Long,
+    ): ResponseEntity<List<NotificationDetailResponse>>
+
+    @SecurityRequirement(name = "JWT")
+    fun updateNotification(
+        @AuthenticationPrincipal userId: Long,
+        @PathVariable notificationId: Long,
+    )
+
+    @SecurityRequirement(name = "JWT")
+    fun createDeviceToken(
+        @AuthenticationPrincipal userId: Long,
+        @RequestBody request: CreateDeviceTokenRequest,
+    )
+
+    @SecurityRequirement(name = "JWT")
+    fun deleteDeviceToken(
+        @AuthenticationPrincipal userId: Long,
+        @PathVariable token: String,
+    )
+}

--- a/bootstrap/api/src/main/kotlin/kr/wooco/woocobe/api/notification/NotificationController.kt
+++ b/bootstrap/api/src/main/kotlin/kr/wooco/woocobe/api/notification/NotificationController.kt
@@ -1,0 +1,66 @@
+package kr.wooco.woocobe.api.notification
+
+import kr.wooco.woocobe.api.notification.request.CreateDeviceTokenRequest
+import kr.wooco.woocobe.api.notification.response.NotificationDetailResponse
+import kr.wooco.woocobe.core.notification.application.port.`in`.CreateDeviceTokenUseCase
+import kr.wooco.woocobe.core.notification.application.port.`in`.DeleteDeviceTokenUseCase
+import kr.wooco.woocobe.core.notification.application.port.`in`.ReadAllNotificationUseCase
+import kr.wooco.woocobe.core.notification.application.port.`in`.UpdateNotificationUseCase
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/notifications")
+class NotificationController(
+    private val readAllNotificationUseCase: ReadAllNotificationUseCase,
+    private val updateNotificationUseCase: UpdateNotificationUseCase,
+    private val createDeviceTokenUseCase: CreateDeviceTokenUseCase,
+    private val deleteDeviceTokenUseCase: DeleteDeviceTokenUseCase,
+) : NotificationApi {
+    @GetMapping
+    override fun getAllUserNotification(
+        @AuthenticationPrincipal userId: Long,
+    ): ResponseEntity<List<NotificationDetailResponse>> {
+        val query = ReadAllNotificationUseCase.Query(userId)
+        val results = readAllNotificationUseCase.readAllNotification(query)
+        return ResponseEntity.ok(NotificationDetailResponse.listFrom(results))
+    }
+
+    @PatchMapping("/{notificationId}")
+    override fun updateNotification(
+        @AuthenticationPrincipal userId: Long,
+        @PathVariable notificationId: Long,
+    ) {
+        val command = UpdateNotificationUseCase.Command(notificationId)
+        updateNotificationUseCase.updateNotification(command)
+    }
+
+    @PostMapping
+    override fun createDeviceToken(
+        @AuthenticationPrincipal userId: Long,
+        @RequestBody request: CreateDeviceTokenRequest,
+    ) {
+        val command = CreateDeviceTokenUseCase.Command(
+            userId = userId,
+            token = request.token,
+        )
+        createDeviceTokenUseCase.createDeviceToken(command)
+    }
+
+    @DeleteMapping("/{token}")
+    override fun deleteDeviceToken(
+        @AuthenticationPrincipal userId: Long,
+        @PathVariable token: String,
+    ) {
+        val command = DeleteDeviceTokenUseCase.Command(token)
+        deleteDeviceTokenUseCase.deleteDeviceToken(command)
+    }
+}

--- a/bootstrap/api/src/main/kotlin/kr/wooco/woocobe/api/notification/request/CreateDeviceTokenRequest.kt
+++ b/bootstrap/api/src/main/kotlin/kr/wooco/woocobe/api/notification/request/CreateDeviceTokenRequest.kt
@@ -1,0 +1,5 @@
+package kr.wooco.woocobe.api.notification.request
+
+data class CreateDeviceTokenRequest(
+    val token: String,
+)

--- a/bootstrap/api/src/main/kotlin/kr/wooco/woocobe/api/notification/response/NotificationDetailResponse.kt
+++ b/bootstrap/api/src/main/kotlin/kr/wooco/woocobe/api/notification/response/NotificationDetailResponse.kt
@@ -1,0 +1,29 @@
+package kr.wooco.woocobe.api.notification.response
+
+import kr.wooco.woocobe.core.notification.application.port.`in`.results.NotificationResult
+import java.time.LocalDateTime
+
+data class NotificationDetailResponse(
+    val id: Long,
+    val userId: Long,
+    val targetId: Long,
+    val targetName: String,
+    var isRead: Boolean,
+    val type: String,
+    val sentAt: LocalDateTime,
+) {
+    companion object {
+        fun from(notificationResult: NotificationResult): NotificationDetailResponse =
+            NotificationDetailResponse(
+                id = notificationResult.id,
+                userId = notificationResult.userId,
+                targetId = notificationResult.targetId,
+                targetName = notificationResult.targetName,
+                isRead = notificationResult.isRead,
+                type = notificationResult.type,
+                sentAt = notificationResult.sentAt,
+            )
+
+        fun listFrom(notificationResults: List<NotificationResult>): List<NotificationDetailResponse> = notificationResults.map { from(it) }
+    }
+}

--- a/bootstrap/api/src/main/kotlin/kr/wooco/woocobe/api/plan/PlanApi.kt
+++ b/bootstrap/api/src/main/kotlin/kr/wooco/woocobe/api/plan/PlanApi.kt
@@ -42,4 +42,10 @@ interface PlanApi {
         @AuthenticationPrincipal userId: Long,
         @PathVariable planId: Long,
     ): ResponseEntity<Unit>
+
+    @SecurityRequirement(name = "JWT")
+    fun sharePlan(
+        @AuthenticationPrincipal userId: Long,
+        @PathVariable planId: Long,
+    ): ResponseEntity<Unit>
 }

--- a/bootstrap/api/src/main/kotlin/kr/wooco/woocobe/api/plan/PlanController.kt
+++ b/bootstrap/api/src/main/kotlin/kr/wooco/woocobe/api/plan/PlanController.kt
@@ -8,6 +8,7 @@ import kr.wooco.woocobe.core.plan.application.port.`in`.CreatePlanUseCase
 import kr.wooco.woocobe.core.plan.application.port.`in`.DeletePlanUseCase
 import kr.wooco.woocobe.core.plan.application.port.`in`.ReadAllPlanUseCase
 import kr.wooco.woocobe.core.plan.application.port.`in`.ReadPlanUseCase
+import kr.wooco.woocobe.core.plan.application.port.`in`.SharePlanUseCase
 import kr.wooco.woocobe.core.plan.application.port.`in`.UpdatePlanUseCase
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
@@ -28,6 +29,7 @@ class PlanController(
     private val deletePlanUseCase: DeletePlanUseCase,
     private val readPlanUseCase: ReadPlanUseCase,
     private val readAllPlanUseCase: ReadAllPlanUseCase,
+    private val sharePlanUseCase: SharePlanUseCase,
 ) : PlanApi {
     @PostMapping
     override fun createPlan(
@@ -76,6 +78,16 @@ class PlanController(
     ): ResponseEntity<Unit> {
         val command = DeletePlanUseCase.Command(userId = userId, planId = planId)
         deletePlanUseCase.deletePlan(command)
+        return ResponseEntity.ok().build()
+    }
+
+    @PatchMapping("/{planId}/share")
+    override fun sharePlan(
+        @AuthenticationPrincipal userId: Long,
+        @PathVariable planId: Long,
+    ): ResponseEntity<Unit> {
+        val command = SharePlanUseCase.Command(userId = userId, planId = planId)
+        sharePlanUseCase.sharePlan(command)
         return ResponseEntity.ok().build()
     }
 }

--- a/core/src/main/kotlin/kr/wooco/woocobe/core/common/config/SchedulingConfig.kt
+++ b/core/src/main/kotlin/kr/wooco/woocobe/core/common/config/SchedulingConfig.kt
@@ -1,0 +1,12 @@
+package kr.wooco.woocobe.core.common.config
+
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan
+import org.springframework.context.annotation.ComponentScan
+import org.springframework.context.annotation.Configuration
+import org.springframework.scheduling.annotation.EnableScheduling
+
+@Configuration
+@EnableScheduling
+@ComponentScan(basePackages = ["kr.wooco.woocobe.core"])
+@ConfigurationPropertiesScan(basePackages = ["kr.wooco.woocobe.core"])
+class SchedulingConfig

--- a/core/src/main/kotlin/kr/wooco/woocobe/core/notification/application/handler/NotificationEventHandler.kt
+++ b/core/src/main/kotlin/kr/wooco/woocobe/core/notification/application/handler/NotificationEventHandler.kt
@@ -1,0 +1,50 @@
+package kr.wooco.woocobe.core.notification.application.handler
+
+import kr.wooco.woocobe.core.coursecomment.domain.event.CourseCommentCreateEvent
+import kr.wooco.woocobe.core.notification.application.port.`in`.CreateNotificationUseCase
+import kr.wooco.woocobe.core.notification.application.port.`in`.ReadDeviceTokenUseCase
+import kr.wooco.woocobe.core.notification.application.port.out.SendNotificationPort
+import kr.wooco.woocobe.core.notification.domain.vo.NotificationType
+import kr.wooco.woocobe.core.plan.domain.event.PlanShareRequestEvent
+import org.springframework.scheduling.annotation.Async
+import org.springframework.stereotype.Component
+import org.springframework.transaction.event.TransactionPhase
+import org.springframework.transaction.event.TransactionalEventListener
+
+@Component
+class NotificationEventHandler(
+    private val sendNotificationPort: SendNotificationPort,
+    private val readDeviceTokenUseCase: ReadDeviceTokenUseCase,
+    private val createNotificationUseCase: CreateNotificationUseCase,
+) {
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    fun handleCourseCommentCreateEvent(event: CourseCommentCreateEvent) {
+        val command = CreateNotificationUseCase.Command(
+            userId = event.courseWriterId,
+            targetId = event.courseId,
+            targetName = event.courseTitle,
+            type = NotificationType.COURSE_COMMENT_CREATED.name,
+        )
+        sendNotification(command)
+    }
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    fun handlePlanShareRequestEvent(event: PlanShareRequestEvent) {
+        val command = CreateNotificationUseCase.Command(
+            userId = event.userId,
+            targetId = event.planId,
+            targetName = event.planTitle,
+            type = NotificationType.PLAN_SHARE_REQUEST.name,
+        )
+        sendNotification(command)
+    }
+
+    private fun sendNotification(command: CreateNotificationUseCase.Command) {
+        val notification = createNotificationUseCase.createNotification(command)
+        val query = ReadDeviceTokenUseCase.Query(notification.userId)
+        val deviceToken = readDeviceTokenUseCase.readDeviceToken(query)
+        sendNotificationPort.sendNotification(notification, deviceToken.token)
+    }
+}

--- a/core/src/main/kotlin/kr/wooco/woocobe/core/notification/application/port/in/CreateDeviceTokenUseCase.kt
+++ b/core/src/main/kotlin/kr/wooco/woocobe/core/notification/application/port/in/CreateDeviceTokenUseCase.kt
@@ -1,0 +1,10 @@
+package kr.wooco.woocobe.core.notification.application.port.`in`
+
+fun interface CreateDeviceTokenUseCase {
+    data class Command(
+        val userId: Long,
+        val token: String,
+    )
+
+    fun createDeviceToken(command: Command)
+}

--- a/core/src/main/kotlin/kr/wooco/woocobe/core/notification/application/port/in/CreateNotificationUseCase.kt
+++ b/core/src/main/kotlin/kr/wooco/woocobe/core/notification/application/port/in/CreateNotificationUseCase.kt
@@ -1,0 +1,14 @@
+package kr.wooco.woocobe.core.notification.application.port.`in`
+
+import kr.wooco.woocobe.core.notification.domain.entity.Notification
+
+fun interface CreateNotificationUseCase {
+    data class Command(
+        val userId: Long,
+        val targetId: Long,
+        val targetName: String,
+        val type: String,
+    )
+
+    fun createNotification(command: Command): Notification
+}

--- a/core/src/main/kotlin/kr/wooco/woocobe/core/notification/application/port/in/DeleteDeviceTokenUseCase.kt
+++ b/core/src/main/kotlin/kr/wooco/woocobe/core/notification/application/port/in/DeleteDeviceTokenUseCase.kt
@@ -1,0 +1,9 @@
+package kr.wooco.woocobe.core.notification.application.port.`in`
+
+fun interface DeleteDeviceTokenUseCase {
+    data class Command(
+        val token: String,
+    )
+
+    fun deleteDeviceToken(command: Command)
+}

--- a/core/src/main/kotlin/kr/wooco/woocobe/core/notification/application/port/in/ReadAllNotificationUseCase.kt
+++ b/core/src/main/kotlin/kr/wooco/woocobe/core/notification/application/port/in/ReadAllNotificationUseCase.kt
@@ -1,0 +1,11 @@
+package kr.wooco.woocobe.core.notification.application.port.`in`
+
+import kr.wooco.woocobe.core.notification.application.port.`in`.results.NotificationResult
+
+fun interface ReadAllNotificationUseCase {
+    data class Query(
+        val userId: Long,
+    )
+
+    fun readAllNotification(query: Query): List<NotificationResult>
+}

--- a/core/src/main/kotlin/kr/wooco/woocobe/core/notification/application/port/in/ReadDeviceTokenUseCase.kt
+++ b/core/src/main/kotlin/kr/wooco/woocobe/core/notification/application/port/in/ReadDeviceTokenUseCase.kt
@@ -1,0 +1,11 @@
+package kr.wooco.woocobe.core.notification.application.port.`in`
+
+import kr.wooco.woocobe.core.notification.application.port.`in`.results.DeviceTokenResult
+
+fun interface ReadDeviceTokenUseCase {
+    data class Query(
+        val userId: Long,
+    )
+
+    fun readDeviceToken(query: Query): DeviceTokenResult
+}

--- a/core/src/main/kotlin/kr/wooco/woocobe/core/notification/application/port/in/UpdateNotificationUseCase.kt
+++ b/core/src/main/kotlin/kr/wooco/woocobe/core/notification/application/port/in/UpdateNotificationUseCase.kt
@@ -1,0 +1,9 @@
+package kr.wooco.woocobe.core.notification.application.port.`in`
+
+fun interface UpdateNotificationUseCase {
+    data class Command(
+        val notificationId: Long,
+    )
+
+    fun updateNotification(command: Command)
+}

--- a/core/src/main/kotlin/kr/wooco/woocobe/core/notification/application/port/in/results/DeviceTokenResult.kt
+++ b/core/src/main/kotlin/kr/wooco/woocobe/core/notification/application/port/in/results/DeviceTokenResult.kt
@@ -1,0 +1,16 @@
+package kr.wooco.woocobe.core.notification.application.port.`in`.results
+
+import kr.wooco.woocobe.core.notification.domain.entity.DeviceToken
+
+data class DeviceTokenResult(
+    val userId: Long,
+    val token: String,
+) {
+    companion object {
+        fun from(deviceToken: DeviceToken): DeviceTokenResult =
+            DeviceTokenResult(
+                userId = deviceToken.userId,
+                token = deviceToken.token,
+            )
+    }
+}

--- a/core/src/main/kotlin/kr/wooco/woocobe/core/notification/application/port/in/results/NotificationResult.kt
+++ b/core/src/main/kotlin/kr/wooco/woocobe/core/notification/application/port/in/results/NotificationResult.kt
@@ -1,0 +1,27 @@
+package kr.wooco.woocobe.core.notification.application.port.`in`.results
+
+import kr.wooco.woocobe.core.notification.domain.entity.Notification
+import java.time.LocalDateTime
+
+data class NotificationResult(
+    val id: Long,
+    val userId: Long,
+    val targetId: Long,
+    val targetName: String,
+    val isRead: Boolean,
+    val type: String,
+    val sentAt: LocalDateTime,
+) {
+    companion object {
+        fun from(notification: Notification): NotificationResult =
+            NotificationResult(
+                id = notification.id,
+                targetId = notification.targetId,
+                targetName = notification.targetName,
+                userId = notification.userId,
+                isRead = notification.isRead,
+                type = notification.type.name,
+                sentAt = notification.sentAt,
+            )
+    }
+}

--- a/core/src/main/kotlin/kr/wooco/woocobe/core/notification/application/port/out/DeleteDeviceTokenPersistencePort.kt
+++ b/core/src/main/kotlin/kr/wooco/woocobe/core/notification/application/port/out/DeleteDeviceTokenPersistencePort.kt
@@ -1,0 +1,5 @@
+package kr.wooco.woocobe.core.notification.application.port.out
+
+interface DeleteDeviceTokenPersistencePort {
+    fun deleteDeviceToKen(token: String)
+}

--- a/core/src/main/kotlin/kr/wooco/woocobe/core/notification/application/port/out/LoadDeviceTokenPersistencePort.kt
+++ b/core/src/main/kotlin/kr/wooco/woocobe/core/notification/application/port/out/LoadDeviceTokenPersistencePort.kt
@@ -1,0 +1,9 @@
+package kr.wooco.woocobe.core.notification.application.port.out
+
+import kr.wooco.woocobe.core.notification.domain.entity.DeviceToken
+
+interface LoadDeviceTokenPersistencePort {
+    fun getByDeviceToken(token: String): DeviceToken
+
+    fun getByUserId(userId: Long): DeviceToken
+}

--- a/core/src/main/kotlin/kr/wooco/woocobe/core/notification/application/port/out/LoadNotificationPersistencePort.kt
+++ b/core/src/main/kotlin/kr/wooco/woocobe/core/notification/application/port/out/LoadNotificationPersistencePort.kt
@@ -1,0 +1,9 @@
+package kr.wooco.woocobe.core.notification.application.port.out
+
+import kr.wooco.woocobe.core.notification.domain.entity.Notification
+
+interface LoadNotificationPersistencePort {
+    fun getByNotificationId(id: Long): Notification
+
+    fun getAllByUserId(userId: Long): List<Notification>
+}

--- a/core/src/main/kotlin/kr/wooco/woocobe/core/notification/application/port/out/SaveDeviceTokenPersistencePort.kt
+++ b/core/src/main/kotlin/kr/wooco/woocobe/core/notification/application/port/out/SaveDeviceTokenPersistencePort.kt
@@ -1,0 +1,7 @@
+package kr.wooco.woocobe.core.notification.application.port.out
+
+import kr.wooco.woocobe.core.notification.domain.entity.DeviceToken
+
+interface SaveDeviceTokenPersistencePort {
+    fun saveDeviceToken(deviceToken: DeviceToken): DeviceToken
+}

--- a/core/src/main/kotlin/kr/wooco/woocobe/core/notification/application/port/out/SaveNotificationPersistencePort.kt
+++ b/core/src/main/kotlin/kr/wooco/woocobe/core/notification/application/port/out/SaveNotificationPersistencePort.kt
@@ -1,0 +1,7 @@
+package kr.wooco.woocobe.core.notification.application.port.out
+
+import kr.wooco.woocobe.core.notification.domain.entity.Notification
+
+interface SaveNotificationPersistencePort {
+    fun saveNotification(notification: Notification): Notification
+}

--- a/core/src/main/kotlin/kr/wooco/woocobe/core/notification/application/port/out/SendNotificationPort.kt
+++ b/core/src/main/kotlin/kr/wooco/woocobe/core/notification/application/port/out/SendNotificationPort.kt
@@ -1,0 +1,10 @@
+package kr.wooco.woocobe.core.notification.application.port.out
+
+import kr.wooco.woocobe.core.notification.domain.entity.Notification
+
+interface SendNotificationPort {
+    fun sendNotification(
+        notification: Notification,
+        token: String,
+    )
+}

--- a/core/src/main/kotlin/kr/wooco/woocobe/core/notification/application/service/NotificationCommandService.kt
+++ b/core/src/main/kotlin/kr/wooco/woocobe/core/notification/application/service/NotificationCommandService.kt
@@ -1,0 +1,59 @@
+package kr.wooco.woocobe.core.notification.application.service
+
+import kr.wooco.woocobe.core.notification.application.port.`in`.CreateDeviceTokenUseCase
+import kr.wooco.woocobe.core.notification.application.port.`in`.CreateNotificationUseCase
+import kr.wooco.woocobe.core.notification.application.port.`in`.DeleteDeviceTokenUseCase
+import kr.wooco.woocobe.core.notification.application.port.`in`.UpdateNotificationUseCase
+import kr.wooco.woocobe.core.notification.application.port.out.DeleteDeviceTokenPersistencePort
+import kr.wooco.woocobe.core.notification.application.port.out.LoadNotificationPersistencePort
+import kr.wooco.woocobe.core.notification.application.port.out.SaveDeviceTokenPersistencePort
+import kr.wooco.woocobe.core.notification.application.port.out.SaveNotificationPersistencePort
+import kr.wooco.woocobe.core.notification.domain.entity.DeviceToken
+import kr.wooco.woocobe.core.notification.domain.entity.Notification
+import kr.wooco.woocobe.core.notification.domain.vo.NotificationType
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class NotificationCommandService(
+    private val loadNotificationPersistencePort: LoadNotificationPersistencePort,
+    private val saveNotificationPersistencePort: SaveNotificationPersistencePort,
+    private val saveDeviceTokenPersistencePort: SaveDeviceTokenPersistencePort,
+    private val deleteDeviceTokenPersistencePort: DeleteDeviceTokenPersistencePort,
+) : CreateNotificationUseCase,
+    UpdateNotificationUseCase,
+    CreateDeviceTokenUseCase,
+    DeleteDeviceTokenUseCase {
+    @Transactional
+    override fun createNotification(command: CreateNotificationUseCase.Command): Notification {
+        val notification = Notification.create(
+            userId = command.userId,
+            targetId = command.targetId,
+            targetName = command.targetName,
+            type = NotificationType.invoke(command.type),
+        )
+        val savedNotification = saveNotificationPersistencePort.saveNotification(notification)
+        return savedNotification
+    }
+
+    @Transactional
+    override fun updateNotification(command: UpdateNotificationUseCase.Command) {
+        val notification = loadNotificationPersistencePort.getByNotificationId(command.notificationId)
+        notification.read()
+        saveNotificationPersistencePort.saveNotification(notification)
+    }
+
+    @Transactional
+    override fun createDeviceToken(command: CreateDeviceTokenUseCase.Command) {
+        val deviceToken = DeviceToken.create(
+            userId = command.userId,
+            token = command.token,
+        )
+        saveDeviceTokenPersistencePort.saveDeviceToken(deviceToken)
+    }
+
+    @Transactional
+    override fun deleteDeviceToken(command: DeleteDeviceTokenUseCase.Command) {
+        deleteDeviceTokenPersistencePort.deleteDeviceToKen(command.token)
+    }
+}

--- a/core/src/main/kotlin/kr/wooco/woocobe/core/notification/application/service/NotificationQueryService.kt
+++ b/core/src/main/kotlin/kr/wooco/woocobe/core/notification/application/service/NotificationQueryService.kt
@@ -1,0 +1,26 @@
+package kr.wooco.woocobe.core.notification.application.service
+
+import kr.wooco.woocobe.core.notification.application.port.`in`.ReadAllNotificationUseCase
+import kr.wooco.woocobe.core.notification.application.port.`in`.ReadDeviceTokenUseCase
+import kr.wooco.woocobe.core.notification.application.port.`in`.results.DeviceTokenResult
+import kr.wooco.woocobe.core.notification.application.port.`in`.results.NotificationResult
+import kr.wooco.woocobe.core.notification.application.port.out.LoadDeviceTokenPersistencePort
+import kr.wooco.woocobe.core.notification.application.port.out.LoadNotificationPersistencePort
+import org.springframework.stereotype.Service
+
+@Service
+class NotificationQueryService(
+    private val loadDeviceTokenPersistencePort: LoadDeviceTokenPersistencePort,
+    private val loadNotificationPersistencePort: LoadNotificationPersistencePort,
+) : ReadAllNotificationUseCase,
+    ReadDeviceTokenUseCase {
+    override fun readAllNotification(query: ReadAllNotificationUseCase.Query): List<NotificationResult> {
+        val notifications = loadNotificationPersistencePort.getAllByUserId(query.userId)
+        return notifications.map { NotificationResult.from(it) }
+    }
+
+    override fun readDeviceToken(query: ReadDeviceTokenUseCase.Query): DeviceTokenResult {
+        val deviceToken = loadDeviceTokenPersistencePort.getByUserId(query.userId)
+        return DeviceTokenResult.from(deviceToken)
+    }
+}

--- a/core/src/main/kotlin/kr/wooco/woocobe/core/notification/domain/entity/DeviceToken.kt
+++ b/core/src/main/kotlin/kr/wooco/woocobe/core/notification/domain/entity/DeviceToken.kt
@@ -1,0 +1,23 @@
+package kr.wooco.woocobe.core.notification.domain.entity
+
+data class DeviceToken(
+    val id: Long,
+    val userId: Long,
+    val token: String,
+    var isActive: Boolean,
+) {
+    fun disable() = apply { if (isActive) isActive = false }
+
+    companion object {
+        fun create(
+            userId: Long,
+            token: String,
+        ): DeviceToken =
+            DeviceToken(
+                id = 0L,
+                userId = userId,
+                isActive = true,
+                token = token,
+            )
+    }
+}

--- a/core/src/main/kotlin/kr/wooco/woocobe/core/notification/domain/entity/Notification.kt
+++ b/core/src/main/kotlin/kr/wooco/woocobe/core/notification/domain/entity/Notification.kt
@@ -1,0 +1,34 @@
+package kr.wooco.woocobe.core.notification.domain.entity
+
+import kr.wooco.woocobe.core.notification.domain.vo.NotificationType
+import java.time.LocalDateTime
+
+data class Notification(
+    val id: Long,
+    val userId: Long,
+    val targetId: Long,
+    val targetName: String,
+    var isRead: Boolean,
+    val type: NotificationType,
+    val sentAt: LocalDateTime,
+) {
+    fun read() = apply { if (!isRead) isRead = true }
+
+    companion object {
+        fun create(
+            userId: Long,
+            targetId: Long,
+            targetName: String,
+            type: NotificationType,
+        ): Notification =
+            Notification(
+                id = 0L,
+                userId = userId,
+                targetId = targetId,
+                targetName = targetName,
+                isRead = false,
+                type = type,
+                sentAt = LocalDateTime.now(),
+            )
+    }
+}

--- a/core/src/main/kotlin/kr/wooco/woocobe/core/notification/domain/exception/NotificationExceptions.kt
+++ b/core/src/main/kotlin/kr/wooco/woocobe/core/notification/domain/exception/NotificationExceptions.kt
@@ -1,0 +1,29 @@
+package kr.wooco.woocobe.core.notification.domain.exception
+
+import kr.wooco.woocobe.common.exception.CustomException
+
+sealed class BaseNotificationException(
+    code: String,
+    message: String,
+) : CustomException(code = code, message = message)
+
+data object NotExistsNotificationException : BaseNotificationException(
+    code = "NOT_EXISTS_NOTIFICATION_EXCEPTION",
+    message = "존재하지 않는 알림입니다.",
+) {
+    private fun readResolve(): Any = NotExistsNotificationException
+}
+
+data object ExpiredNotificationException : BaseNotificationException(
+    code = "EXPIRED_NOTIFICATION_EXCEPTION",
+    message = "유효기간이 만료된 알림입니다.",
+) {
+    private fun readResolve(): Any = ExpiredNotificationException
+}
+
+data object InvalidNotificationTypeException : BaseNotificationException(
+    code = "INVALID_NOTIFICATION_TYPE_EXCEPTION",
+    message = "유효하지 않은 알림 타입입니다.",
+) {
+    private fun readResolve(): Any = InvalidNotificationTypeException
+}

--- a/core/src/main/kotlin/kr/wooco/woocobe/core/notification/domain/vo/NotificationType.kt
+++ b/core/src/main/kotlin/kr/wooco/woocobe/core/notification/domain/vo/NotificationType.kt
@@ -1,0 +1,13 @@
+package kr.wooco.woocobe.core.notification.domain.vo
+
+enum class NotificationType {
+    COURSE_COMMENT_CREATED,
+    PLAN_SHARE_REQUEST,
+    PLACE_REVIEW_REQUEST,
+    SYSTEM,
+    ;
+
+    companion object {
+        operator fun invoke(value: String) = NotificationType.valueOf(value)
+    }
+}

--- a/core/src/main/kotlin/kr/wooco/woocobe/core/plan/application/port/in/SharePlanUseCase.kt
+++ b/core/src/main/kotlin/kr/wooco/woocobe/core/plan/application/port/in/SharePlanUseCase.kt
@@ -1,0 +1,10 @@
+package kr.wooco.woocobe.core.plan.application.port.`in`
+
+fun interface SharePlanUseCase {
+    data class Command(
+        val userId: Long,
+        val planId: Long,
+    )
+
+    fun sharePlan(command: Command)
+}

--- a/core/src/main/kotlin/kr/wooco/woocobe/core/plan/application/port/out/LoadPlanPersistencePort.kt
+++ b/core/src/main/kotlin/kr/wooco/woocobe/core/plan/application/port/out/LoadPlanPersistencePort.kt
@@ -6,4 +6,6 @@ interface LoadPlanPersistencePort {
     fun getByPlanId(planId: Long): Plan
 
     fun getAllByUserId(userId: Long): List<Plan>
+
+    fun getAllByIsSharedFalse(): List<Plan>
 }

--- a/core/src/main/kotlin/kr/wooco/woocobe/core/plan/application/scheduler/PlanScheduler.kt
+++ b/core/src/main/kotlin/kr/wooco/woocobe/core/plan/application/scheduler/PlanScheduler.kt
@@ -1,0 +1,28 @@
+package kr.wooco.woocobe.core.plan.application.scheduler
+
+import kr.wooco.woocobe.core.plan.application.port.out.LoadPlanPersistencePort
+import kr.wooco.woocobe.core.plan.domain.event.PlanShareRequestEvent
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+class PlanScheduler(
+    private val loadPlanPersistencePort: LoadPlanPersistencePort,
+    private val eventPublisher: ApplicationEventPublisher,
+) {
+    @Transactional
+    @Scheduled(cron = "0 0 * * * ?")
+    fun checkUnsharedPlan() {
+        loadPlanPersistencePort
+            .getAllByIsSharedFalse()
+            .map {
+                PlanShareRequestEvent(
+                    userId = it.userId,
+                    planId = it.id,
+                    planTitle = it.title,
+                )
+            }.forEach(eventPublisher::publishEvent)
+    }
+}

--- a/core/src/main/kotlin/kr/wooco/woocobe/core/plan/application/service/PlanCommandService.kt
+++ b/core/src/main/kotlin/kr/wooco/woocobe/core/plan/application/service/PlanCommandService.kt
@@ -2,6 +2,7 @@ package kr.wooco.woocobe.core.plan.application.service
 
 import kr.wooco.woocobe.core.plan.application.port.`in`.CreatePlanUseCase
 import kr.wooco.woocobe.core.plan.application.port.`in`.DeletePlanUseCase
+import kr.wooco.woocobe.core.plan.application.port.`in`.SharePlanUseCase
 import kr.wooco.woocobe.core.plan.application.port.`in`.UpdatePlanUseCase
 import kr.wooco.woocobe.core.plan.application.port.out.DeletePlanPersistencePort
 import kr.wooco.woocobe.core.plan.application.port.out.LoadPlanPersistencePort
@@ -18,7 +19,8 @@ internal class PlanCommandService(
     private val deletePlanPersistencePort: DeletePlanPersistencePort,
 ) : CreatePlanUseCase,
     UpdatePlanUseCase,
-    DeletePlanUseCase {
+    DeletePlanUseCase,
+    SharePlanUseCase {
     @Transactional
     override fun createPlan(command: CreatePlanUseCase.Command): Long {
         val planRegion = PlanRegion(
@@ -59,5 +61,13 @@ internal class PlanCommandService(
         val plan = loadPlanPersistencePort.getByPlanId(command.planId)
         plan.validateWriter(command.userId)
         deletePlanPersistencePort.deleteByPlanId(plan.id)
+    }
+
+    @Transactional
+    override fun sharePlan(command: SharePlanUseCase.Command) {
+        val plan = loadPlanPersistencePort.getByPlanId(command.planId)
+        plan.validateWriter(command.userId)
+        plan.share()
+        savePlanPersistencePort.savePlan(plan)
     }
 }

--- a/core/src/main/kotlin/kr/wooco/woocobe/core/plan/domain/entity/Plan.kt
+++ b/core/src/main/kotlin/kr/wooco/woocobe/core/plan/domain/entity/Plan.kt
@@ -5,12 +5,13 @@ import kr.wooco.woocobe.core.plan.domain.vo.PlanPlace
 import kr.wooco.woocobe.core.plan.domain.vo.PlanRegion
 import java.time.LocalDate
 
-class Plan(
+data class Plan(
     val id: Long,
     val userId: Long,
     var title: String,
     var contents: String,
     var region: PlanRegion,
+    var isShared: Boolean,
     var visitDate: LocalDate,
     var places: List<PlanPlace>,
 ) {
@@ -35,6 +36,10 @@ class Plan(
         if (this.userId != userId) throw InvalidPlanWriterException
     }
 
+    fun share() {
+        if (!isShared) isShared = true
+    }
+
     companion object {
         fun create(
             userId: Long,
@@ -50,6 +55,7 @@ class Plan(
                 title = title,
                 contents = contents,
                 region = region,
+                isShared = false,
                 visitDate = visitDate,
                 places = processPlanPlaceOrder(placeIds),
             )

--- a/core/src/main/kotlin/kr/wooco/woocobe/core/plan/domain/event/PlanShareRequestEvent.kt
+++ b/core/src/main/kotlin/kr/wooco/woocobe/core/plan/domain/event/PlanShareRequestEvent.kt
@@ -1,0 +1,7 @@
+package kr.wooco.woocobe.core.plan.domain.event
+
+data class PlanShareRequestEvent(
+    val userId: Long,
+    val planId: Long,
+    val planTitle: String,
+)

--- a/infrastructure/fcm/src/main/kotlin/kr/wooco/woocobe/fcm/notification/SendNotificationFcmAdapter.kt
+++ b/infrastructure/fcm/src/main/kotlin/kr/wooco/woocobe/fcm/notification/SendNotificationFcmAdapter.kt
@@ -1,0 +1,27 @@
+package kr.wooco.woocobe.fcm.notification
+
+import com.google.firebase.messaging.FirebaseMessaging
+import com.google.firebase.messaging.Message
+import kr.wooco.woocobe.core.notification.application.port.out.SendNotificationPort
+import kr.wooco.woocobe.core.notification.domain.entity.Notification
+import org.springframework.stereotype.Component
+
+@Component
+internal class SendNotificationFcmAdapter : SendNotificationPort {
+    override fun sendNotification(
+        notification: Notification,
+        token: String,
+    ) {
+        val message = Message
+            .builder()
+            .setToken(token)
+            .putData("notificationId", notification.id.toString())
+            .putData("userId", notification.userId.toString())
+            .putData("targetId", notification.targetId.toString())
+            .putData("targetName", notification.targetName)
+            .putData("type", notification.type.name)
+            .putData("isRead", notification.isRead.toString())
+            .build()
+        FirebaseMessaging.getInstance().send(message)
+    }
+}

--- a/infrastructure/mysql/src/main/kotlin/kr/wooco/woocobe/mysql/notification/DeviceTokenPersistenceAdapter.kt
+++ b/infrastructure/mysql/src/main/kotlin/kr/wooco/woocobe/mysql/notification/DeviceTokenPersistenceAdapter.kt
@@ -1,0 +1,41 @@
+package kr.wooco.woocobe.mysql.notification
+
+import kr.wooco.woocobe.core.notification.application.port.out.DeleteDeviceTokenPersistencePort
+import kr.wooco.woocobe.core.notification.application.port.out.LoadDeviceTokenPersistencePort
+import kr.wooco.woocobe.core.notification.application.port.out.SaveDeviceTokenPersistencePort
+import kr.wooco.woocobe.core.notification.domain.entity.DeviceToken
+import kr.wooco.woocobe.mysql.notification.repository.DeviceTokenJpaRepository
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+internal class DeviceTokenPersistenceAdapter(
+    private val deviceTokenJpaRepository: DeviceTokenJpaRepository,
+    private val deviceTokenPersistenceMapper: DeviceTokenPersistenceMapper,
+) : LoadDeviceTokenPersistencePort,
+    SaveDeviceTokenPersistencePort,
+    DeleteDeviceTokenPersistencePort {
+    @Transactional(readOnly = true)
+    override fun getByDeviceToken(token: String): DeviceToken {
+        val deviceTokenJpaEntity = deviceTokenJpaRepository.findByToken(token)
+        return deviceTokenPersistenceMapper.toDomain(deviceTokenJpaEntity)
+    }
+
+    @Transactional(readOnly = true)
+    override fun getByUserId(userId: Long): DeviceToken {
+        val deviceTokenJpaEntity = deviceTokenJpaRepository.findByUserId(userId)
+        return deviceTokenPersistenceMapper.toDomain(deviceTokenJpaEntity)
+    }
+
+    @Transactional(readOnly = true)
+    override fun saveDeviceToken(deviceToken: DeviceToken): DeviceToken {
+        val deviceTokenJpaEntity = deviceTokenPersistenceMapper.toEntity(deviceToken)
+        deviceTokenJpaRepository.save(deviceTokenJpaEntity)
+        return deviceTokenPersistenceMapper.toDomain(deviceTokenJpaEntity)
+    }
+
+    @Transactional(readOnly = true)
+    override fun deleteDeviceToKen(token: String) {
+        deviceTokenJpaRepository.deleteByToken(token)
+    }
+}

--- a/infrastructure/mysql/src/main/kotlin/kr/wooco/woocobe/mysql/notification/DeviceTokenPersistenceMapper.kt
+++ b/infrastructure/mysql/src/main/kotlin/kr/wooco/woocobe/mysql/notification/DeviceTokenPersistenceMapper.kt
@@ -1,0 +1,24 @@
+package kr.wooco.woocobe.mysql.notification
+
+import kr.wooco.woocobe.core.notification.domain.entity.DeviceToken
+import kr.wooco.woocobe.mysql.notification.entity.DeviceTokenJpaEntity
+import org.springframework.stereotype.Component
+
+@Component
+internal class DeviceTokenPersistenceMapper {
+    fun toDomain(deviceTokenJpaEntity: DeviceTokenJpaEntity): DeviceToken =
+        DeviceToken(
+            id = deviceTokenJpaEntity.id,
+            userId = deviceTokenJpaEntity.userId,
+            token = deviceTokenJpaEntity.token,
+            isActive = deviceTokenJpaEntity.isActive,
+        )
+
+    fun toEntity(deviceToken: DeviceToken): DeviceTokenJpaEntity =
+        DeviceTokenJpaEntity(
+            id = deviceToken.id,
+            userId = deviceToken.userId,
+            token = deviceToken.token,
+            isActive = deviceToken.isActive,
+        )
+}

--- a/infrastructure/mysql/src/main/kotlin/kr/wooco/woocobe/mysql/notification/NotificationPersistenceAdapter.kt
+++ b/infrastructure/mysql/src/main/kotlin/kr/wooco/woocobe/mysql/notification/NotificationPersistenceAdapter.kt
@@ -1,0 +1,33 @@
+package kr.wooco.woocobe.mysql.notification
+
+import kr.wooco.woocobe.core.notification.application.port.out.LoadNotificationPersistencePort
+import kr.wooco.woocobe.core.notification.application.port.out.SaveNotificationPersistencePort
+import kr.wooco.woocobe.core.notification.domain.entity.Notification
+import kr.wooco.woocobe.core.notification.domain.exception.NotExistsNotificationException
+import kr.wooco.woocobe.mysql.notification.repository.NotificationJpaRepository
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Component
+
+@Component
+internal class NotificationPersistenceAdapter(
+    private val notificationJpaRepository: NotificationJpaRepository,
+    private val notificationPersistenceMapper: NotificationPersistenceMapper,
+) : LoadNotificationPersistencePort,
+    SaveNotificationPersistencePort {
+    override fun getByNotificationId(id: Long): Notification {
+        val notificationJpaEntity = notificationJpaRepository.findByIdOrNull(id)
+            ?: throw NotExistsNotificationException
+        return notificationPersistenceMapper.toDomain(notificationJpaEntity)
+    }
+
+    override fun getAllByUserId(userId: Long): List<Notification> {
+        val notificationJpaEntities = notificationJpaRepository.findAllByUserId(userId)
+        return notificationJpaEntities.map { notificationPersistenceMapper.toDomain(it) }
+    }
+
+    override fun saveNotification(notification: Notification): Notification {
+        val notificationJpaEntity = notificationPersistenceMapper.toEntity(notification)
+        notificationJpaRepository.save(notificationJpaEntity)
+        return notificationPersistenceMapper.toDomain(notificationJpaEntity)
+    }
+}

--- a/infrastructure/mysql/src/main/kotlin/kr/wooco/woocobe/mysql/notification/NotificationPersistenceMapper.kt
+++ b/infrastructure/mysql/src/main/kotlin/kr/wooco/woocobe/mysql/notification/NotificationPersistenceMapper.kt
@@ -1,0 +1,30 @@
+package kr.wooco.woocobe.mysql.notification
+
+import kr.wooco.woocobe.core.notification.domain.entity.Notification
+import kr.wooco.woocobe.core.notification.domain.vo.NotificationType
+import kr.wooco.woocobe.mysql.notification.entity.NotificationJpaEntity
+import org.springframework.stereotype.Component
+
+@Component
+internal class NotificationPersistenceMapper {
+    fun toDomain(notificationJpaEntity: NotificationJpaEntity): Notification =
+        Notification(
+            id = notificationJpaEntity.id,
+            userId = notificationJpaEntity.userId,
+            targetId = notificationJpaEntity.targetId,
+            targetName = notificationJpaEntity.targetName,
+            isRead = notificationJpaEntity.isRead,
+            type = NotificationType.invoke(notificationJpaEntity.type),
+            sentAt = notificationJpaEntity.createdAt,
+        )
+
+    fun toEntity(notification: Notification): NotificationJpaEntity =
+        NotificationJpaEntity(
+            id = notification.id,
+            userId = notification.userId,
+            targetId = notification.targetId,
+            targetName = notification.targetName,
+            isRead = notification.isRead,
+            type = notification.type.name,
+        )
+}

--- a/infrastructure/mysql/src/main/kotlin/kr/wooco/woocobe/mysql/notification/entity/DeviceTokenJpaEntity.kt
+++ b/infrastructure/mysql/src/main/kotlin/kr/wooco/woocobe/mysql/notification/entity/DeviceTokenJpaEntity.kt
@@ -1,0 +1,22 @@
+package kr.wooco.woocobe.mysql.notification.entity
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import kr.wooco.woocobe.mysql.common.entity.BaseTimeEntity
+import kr.wooco.woocobe.mysql.common.utils.Tsid
+
+@Entity
+@Table(name = "device_tokens")
+class DeviceTokenJpaEntity(
+    @Column(name = "token", unique = true)
+    val token: String,
+    @Column(name = "user_id")
+    val userId: Long,
+    @Column(name = "is_active")
+    val isActive: Boolean,
+    @Id @Tsid
+    @Column(name = "device_token_id")
+    override val id: Long = 0L,
+) : BaseTimeEntity()

--- a/infrastructure/mysql/src/main/kotlin/kr/wooco/woocobe/mysql/notification/entity/NotificationJpaEntity.kt
+++ b/infrastructure/mysql/src/main/kotlin/kr/wooco/woocobe/mysql/notification/entity/NotificationJpaEntity.kt
@@ -1,0 +1,26 @@
+package kr.wooco.woocobe.mysql.notification.entity
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import kr.wooco.woocobe.mysql.common.entity.BaseTimeEntity
+import kr.wooco.woocobe.mysql.common.utils.Tsid
+
+@Entity
+@Table(name = "notifications")
+class NotificationJpaEntity(
+    @Column(name = "user_id")
+    val userId: Long,
+    @Column(name = "target_id")
+    val targetId: Long,
+    @Column(name = "target_name")
+    val targetName: String,
+    @Column(name = "is_read")
+    val isRead: Boolean,
+    @Column(name = "type")
+    val type: String,
+    @Id @Tsid
+    @Column(name = "notification_id")
+    override val id: Long = 0L,
+) : BaseTimeEntity()

--- a/infrastructure/mysql/src/main/kotlin/kr/wooco/woocobe/mysql/notification/repository/DeviceTokenJpaRepository.kt
+++ b/infrastructure/mysql/src/main/kotlin/kr/wooco/woocobe/mysql/notification/repository/DeviceTokenJpaRepository.kt
@@ -1,0 +1,12 @@
+package kr.wooco.woocobe.mysql.notification.repository
+
+import kr.wooco.woocobe.mysql.notification.entity.DeviceTokenJpaEntity
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface DeviceTokenJpaRepository : JpaRepository<DeviceTokenJpaEntity, Long> {
+    fun findByToken(token: String): DeviceTokenJpaEntity
+
+    fun findByUserId(userId: Long): DeviceTokenJpaEntity
+
+    fun deleteByToken(token: String)
+}

--- a/infrastructure/mysql/src/main/kotlin/kr/wooco/woocobe/mysql/notification/repository/NotificationJpaRepository.kt
+++ b/infrastructure/mysql/src/main/kotlin/kr/wooco/woocobe/mysql/notification/repository/NotificationJpaRepository.kt
@@ -1,0 +1,8 @@
+package kr.wooco.woocobe.mysql.notification.repository
+
+import kr.wooco.woocobe.mysql.notification.entity.NotificationJpaEntity
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface NotificationJpaRepository : JpaRepository<NotificationJpaEntity, Long> {
+    fun findAllByUserId(userId: Long): List<NotificationJpaEntity>
+}

--- a/infrastructure/mysql/src/main/kotlin/kr/wooco/woocobe/mysql/plan/PlanPersistenceAdapter.kt
+++ b/infrastructure/mysql/src/main/kotlin/kr/wooco/woocobe/mysql/plan/PlanPersistenceAdapter.kt
@@ -39,6 +39,19 @@ internal class PlanPersistenceAdapter(
         }
     }
 
+    override fun getAllByIsSharedFalse(): List<Plan> {
+        val planEntities = planJpaRepository.findAllByIsSharedFalse()
+        val planIds = planEntities.map { it.id }
+        val planPlaceEntities = planPlaceJpaRepository.findAllByPlanIdIn(planIds)
+
+        return planEntities.map { planJpaEntity ->
+            planPersistenceMapper.toDomain(
+                planJpaEntity = planJpaEntity,
+                planPlaceJpaEntities = planPlaceEntities.filter { it.planId == planJpaEntity.id },
+            )
+        }
+    }
+
     override fun savePlan(plan: Plan): Plan {
         val planEntity = planJpaRepository.save(planPersistenceMapper.toEntity(plan))
 

--- a/infrastructure/mysql/src/main/kotlin/kr/wooco/woocobe/mysql/plan/PlanPersistenceMapper.kt
+++ b/infrastructure/mysql/src/main/kotlin/kr/wooco/woocobe/mysql/plan/PlanPersistenceMapper.kt
@@ -22,6 +22,7 @@ internal class PlanPersistenceMapper {
                 primaryRegion = planJpaEntity.primaryRegion,
                 secondaryRegion = planJpaEntity.secondaryRegion,
             ),
+            isShared = planJpaEntity.isShared,
             visitDate = planJpaEntity.visitDate,
             places = planPlaceJpaEntities.map { PlanPlace(order = it.order, placeId = it.placeId) },
         )
@@ -34,6 +35,7 @@ internal class PlanPersistenceMapper {
             contents = plan.contents,
             primaryRegion = plan.region.primaryRegion,
             secondaryRegion = plan.region.secondaryRegion,
+            isShared = plan.isShared,
             visitDate = plan.visitDate,
         )
 }

--- a/infrastructure/mysql/src/main/kotlin/kr/wooco/woocobe/mysql/plan/entity/PlanJpaEntity.kt
+++ b/infrastructure/mysql/src/main/kotlin/kr/wooco/woocobe/mysql/plan/entity/PlanJpaEntity.kt
@@ -21,6 +21,8 @@ class PlanJpaEntity(
     val primaryRegion: String,
     @Column(name = "secondary_region")
     val secondaryRegion: String,
+    @Column(name = "is_shared")
+    val isShared: Boolean,
     @Column(name = "visit_date")
     val visitDate: LocalDate,
     @Id @Tsid

--- a/infrastructure/mysql/src/main/kotlin/kr/wooco/woocobe/mysql/plan/repository/PlanJpaRepository.kt
+++ b/infrastructure/mysql/src/main/kotlin/kr/wooco/woocobe/mysql/plan/repository/PlanJpaRepository.kt
@@ -5,4 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository
 
 interface PlanJpaRepository : JpaRepository<PlanJpaEntity, Long> {
     fun findAllByUserId(userId: Long): List<PlanJpaEntity>
+
+    fun findAllByIsSharedFalse(): List<PlanJpaEntity>
 }


### PR DESCRIPTION
## 📝 개요

알림 도메인을 정의하고, 관련 기능을 추가합니다.


## ✨ 변경 사항

- ✨ 알림 `(Notification)` 도메인 기능 및 API 추가
- ✨ 디바이스 토큰 (`DeviceToken`) 기능 및 API 추가
- ✨ FCM 전송을 위한 포트 및 어댑터 추가
- ✨ 알림 전송을 위한 이벤트 핸들러 및 스케줄러 추가

## 🔗 관련 이슈

- closed #16 

## ℹ️ 참고 사항

- 현재 API 및 알림 전송 테스트는 해봤지만, 놓친 부분이 있을 수 있습니다. 
- 패키지 구조, 클래스 및 변수명 등 네이밍은 언제든지 변경할 수 있습니다.
- 알림 전송시 단순히 `Spring -> FCM` 구조이지만, 추후 필요에 따라 아키텍처는 변경될 수 있습니다.
- 모든 예외 상황 및 필요 기능 에 대응하지 않았습니다. ex) FCM 전송 실패시 처리, 유저별로 여러 디바이스 토큰 보유 가능 등
- 파일 추가 및 변경이 많아 천천히 보시고, 논리적으로 모순되는 부분이나 오탈자 등 어떤 종류라도 수정 사항이 있다면 알려주시면 감사합니다.
- 기획적으로 회의가 필요한 부분이 몇몇 있습니다. 해당 PR의 최우선 목표는 `알림 기능 구현`입니다. 따라서 추후 변경되더라도 1차적으로 실행되는 것이 중요하다고 판단했습니다. 