### PR TITLE
feat: 장소 썸네일 이미지 추출 로직 추가

### DIFF
--- a/bootstrap/api/src/main/kotlin/kr/wooco/woocobe/api/place/PlaceController.kt
+++ b/bootstrap/api/src/main/kotlin/kr/wooco/woocobe/api/place/PlaceController.kt
@@ -3,7 +3,7 @@ package kr.wooco.woocobe.api.place
 import kr.wooco.woocobe.api.place.request.CreatePlaceRequest
 import kr.wooco.woocobe.api.place.response.CreatePlaceResponse
 import kr.wooco.woocobe.api.place.response.PlaceDetailResponse
-import kr.wooco.woocobe.core.place.application.port.`in`.CreatePlaceUseCase
+import kr.wooco.woocobe.core.place.application.port.`in`.CreatePlaceIfNotExistsUseCase
 import kr.wooco.woocobe.core.place.application.port.`in`.ReadPlaceUseCase
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
@@ -18,7 +18,7 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 @RequestMapping("/api/v1/places")
 class PlaceController(
-    private val createPlaceUseCase: CreatePlaceUseCase,
+    private val createPlaceIfNotExistsUseCase: CreatePlaceIfNotExistsUseCase,
     private val readPlaceUseCase: ReadPlaceUseCase,
 ) : PlaceApi {
     @GetMapping("/{placeId}")
@@ -36,7 +36,7 @@ class PlaceController(
         @RequestBody request: CreatePlaceRequest,
     ): ResponseEntity<CreatePlaceResponse> {
         val command = request.toCommand()
-        val result = createPlaceUseCase.createPlace(command)
+        val result = createPlaceIfNotExistsUseCase.createPlaceIfNotExists(command)
         return ResponseEntity.status(HttpStatus.CREATED).body(CreatePlaceResponse(result))
     }
 }

--- a/core/src/main/kotlin/kr/wooco/woocobe/core/place/application/handler/PlaceEventHandler.kt
+++ b/core/src/main/kotlin/kr/wooco/woocobe/core/place/application/handler/PlaceEventHandler.kt
@@ -1,19 +1,29 @@
 package kr.wooco.woocobe.core.place.application.handler
 
+import kr.wooco.woocobe.core.place.application.port.`in`.UpdatePlaceImageUseCase
 import kr.wooco.woocobe.core.place.application.port.out.LoadPlacePersistencePort
 import kr.wooco.woocobe.core.place.application.port.out.SavePlacePersistencePort
+import kr.wooco.woocobe.core.place.domain.event.PlaceCreateEvent
 import kr.wooco.woocobe.core.placereview.domain.event.PlaceReviewCreateEvent
 import kr.wooco.woocobe.core.placereview.domain.event.PlaceReviewDeleteEvent
 import kr.wooco.woocobe.core.placereview.domain.event.PlaceReviewUpdateEvent
+import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Service
 import org.springframework.transaction.event.TransactionPhase
 import org.springframework.transaction.event.TransactionalEventListener
 
 @Service
 internal class PlaceEventHandler(
+    private val updatePlaceImageUseCase: UpdatePlaceImageUseCase,
     private val loadPlacePersistencePort: LoadPlacePersistencePort,
     private val savePlacePersistencePort: SavePlacePersistencePort,
 ) {
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    fun handlePlaceCreateEvent(event: PlaceCreateEvent) {
+        updatePlaceImageUseCase.updatePlaceImage(UpdatePlaceImageUseCase.Command(event.placeId))
+    }
+
     @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
     fun handlePlaceReviewCreateEvent(event: PlaceReviewCreateEvent) {
         val place = loadPlacePersistencePort

--- a/core/src/main/kotlin/kr/wooco/woocobe/core/place/application/port/in/CreatePlaceIfNotExistsUseCase.kt
+++ b/core/src/main/kotlin/kr/wooco/woocobe/core/place/application/port/in/CreatePlaceIfNotExistsUseCase.kt
@@ -1,6 +1,6 @@
 package kr.wooco.woocobe.core.place.application.port.`in`
 
-fun interface CreatePlaceUseCase {
+fun interface CreatePlaceIfNotExistsUseCase {
     data class Command(
         val name: String,
         val latitude: Double,
@@ -10,5 +10,5 @@ fun interface CreatePlaceUseCase {
         val phoneNumber: String,
     )
 
-    fun createPlace(command: Command): Long
+    fun createPlaceIfNotExists(command: Command): Long
 }

--- a/core/src/main/kotlin/kr/wooco/woocobe/core/place/application/port/in/UpdatePlaceImageUseCase.kt
+++ b/core/src/main/kotlin/kr/wooco/woocobe/core/place/application/port/in/UpdatePlaceImageUseCase.kt
@@ -1,0 +1,9 @@
+package kr.wooco.woocobe.core.place.application.port.`in`
+
+fun interface UpdatePlaceImageUseCase {
+    data class Command(
+        val placeId: Long,
+    )
+
+    fun updatePlaceImage(command: Command)
+}

--- a/core/src/main/kotlin/kr/wooco/woocobe/core/place/application/port/out/PlaceClientPort.kt
+++ b/core/src/main/kotlin/kr/wooco/woocobe/core/place/application/port/out/PlaceClientPort.kt
@@ -1,0 +1,8 @@
+package kr.wooco.woocobe.core.place.application.port.out
+
+interface PlaceClientPort {
+    fun fetchPlaceThumbnailUrl(
+        name: String,
+        address: String,
+    ): String?
+}

--- a/core/src/main/kotlin/kr/wooco/woocobe/core/place/application/service/PlaceCommandService.kt
+++ b/core/src/main/kotlin/kr/wooco/woocobe/core/place/application/service/PlaceCommandService.kt
@@ -1,30 +1,39 @@
 package kr.wooco.woocobe.core.place.application.service
 
-import kr.wooco.woocobe.core.place.application.port.`in`.CreatePlaceUseCase
+import kr.wooco.woocobe.core.place.application.port.`in`.CreatePlaceIfNotExistsUseCase
+import kr.wooco.woocobe.core.place.application.port.`in`.PlaceClientPort
 import kr.wooco.woocobe.core.place.application.port.out.LoadPlacePersistencePort
 import kr.wooco.woocobe.core.place.application.port.out.SavePlacePersistencePort
 import kr.wooco.woocobe.core.place.domain.entity.Place
+import kr.wooco.woocobe.core.place.domain.event.PlaceCreateEvent
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
 @Service
 internal class PlaceCommandService(
+    private val eventPublisher: ApplicationEventPublisher,
+    private val placeClientPort: PlaceClientPort,
     private val savePlacePersistencePort: SavePlacePersistencePort,
     private val loadPlacePersistencePort: LoadPlacePersistencePort,
-) : CreatePlaceUseCase {
+) : CreatePlaceIfNotExistsUseCase {
     @Transactional
-    override fun createPlace(command: CreatePlaceUseCase.Command): Long {
-        val place = loadPlacePersistencePort.getOrNullByKakaoMapPlaceId(command.kakaoPlaceId)
-            ?: savePlacePersistencePort.savePlace(
-                Place.create(
-                    name = command.name,
-                    kakaoPlaceId = command.kakaoPlaceId,
-                    address = command.address,
-                    latitude = command.latitude,
-                    longitude = command.longitude,
-                    phoneNumber = command.phoneNumber,
-                ),
-            )
+    override fun createPlaceIfNotExists(command: CreatePlaceIfNotExistsUseCase.Command): Long =
+        loadPlacePersistencePort.getOrNullByKakaoMapPlaceId(command.kakaoPlaceId)?.id
+            ?: createPlace(command)
+
+    private fun createPlace(command: CreatePlaceIfNotExistsUseCase.Command): Long {
+        val place = savePlacePersistencePort.savePlace(
+            Place.create(
+                name = command.name,
+                kakaoPlaceId = command.kakaoPlaceId,
+                address = command.address,
+                latitude = command.latitude,
+                longitude = command.longitude,
+                phoneNumber = command.phoneNumber,
+            ),
+        )
+        eventPublisher.publishEvent(PlaceCreateEvent.from(place))
         return place.id
     }
 }

--- a/core/src/main/kotlin/kr/wooco/woocobe/core/place/domain/entity/Place.kt
+++ b/core/src/main/kotlin/kr/wooco/woocobe/core/place/domain/entity/Place.kt
@@ -16,9 +16,20 @@ data class Place(
         require(reviewCount >= 0) { "리뷰 수는 0 미만으로 설정할 수 없습니다." }
     }
 
-    fun increaseReviewCounts(): Place = copy(reviewCount = reviewCount + 1)
+    fun increaseReviewCounts(): Place =
+        copy(
+            reviewCount = reviewCount + 1,
+        )
 
-    fun decreaseReviewCounts(): Place = copy(reviewCount = reviewCount - 1)
+    fun decreaseReviewCounts(): Place =
+        copy(
+            reviewCount = reviewCount - 1,
+        )
+
+    fun updateThumbnail(thumbnailUrl: String): Place =
+        copy(
+            thumbnailUrl = thumbnailUrl,
+        )
 
     fun processPlaceStats(
         currentReviewRate: Double,

--- a/core/src/main/kotlin/kr/wooco/woocobe/core/place/domain/event/PlaceCreateEvent.kt
+++ b/core/src/main/kotlin/kr/wooco/woocobe/core/place/domain/event/PlaceCreateEvent.kt
@@ -1,0 +1,18 @@
+package kr.wooco.woocobe.core.place.domain.event
+
+import kr.wooco.woocobe.core.place.domain.entity.Place
+
+data class PlaceCreateEvent(
+    val placeId: Long,
+    val name: String,
+    val address: String,
+) {
+    companion object {
+        fun from(place: Place): PlaceCreateEvent =
+            PlaceCreateEvent(
+                placeId = place.id,
+                name = place.name,
+                address = place.address,
+            )
+    }
+}

--- a/infrastructure/rest/src/main/kotlin/kr/wooco/woocobe/rest/common/config/RestConfig.kt
+++ b/infrastructure/rest/src/main/kotlin/kr/wooco/woocobe/rest/common/config/RestConfig.kt
@@ -2,6 +2,7 @@ package kr.wooco.woocobe.rest.common.config
 
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kr.wooco.woocobe.rest.auth.kakao.KakaoSocialAuthApiClient
+import kr.wooco.woocobe.rest.place.GooglePlaceApiClient
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.ComponentScan
@@ -17,11 +18,16 @@ import org.springframework.web.service.invoker.HttpServiceProxyFactory
 @ConfigurationPropertiesScan(basePackages = ["kr.wooco.woocobe.rest"])
 class RestConfig {
     @Bean
-    fun kakaoSocialAuthApiClient(): KakaoSocialAuthApiClient =
+    fun googlePlaceApiClient(): GooglePlaceApiClient = createHttpInterface(GooglePlaceApiClient::class.java)
+
+    @Bean
+    fun kakaoSocialAuthApiClient(): KakaoSocialAuthApiClient = createHttpInterface(KakaoSocialAuthApiClient::class.java)
+
+    private fun <T> createHttpInterface(clazz: Class<T>): T =
         HttpServiceProxyFactory
             .builderFor(RestClientAdapter.create(generateRestClient()))
             .build()
-            .createClient(KakaoSocialAuthApiClient::class.java)
+            .createClient(clazz)
 
     private fun generateRestClient(): RestClient =
         RestClient

--- a/infrastructure/rest/src/main/kotlin/kr/wooco/woocobe/rest/place/GooglePlaceApiClient.kt
+++ b/infrastructure/rest/src/main/kotlin/kr/wooco/woocobe/rest/place/GooglePlaceApiClient.kt
@@ -1,0 +1,31 @@
+package kr.wooco.woocobe.rest.place
+
+import kr.wooco.woocobe.rest.place.response.GooglePlaceDetailsResponse
+import kr.wooco.woocobe.rest.place.response.GooglePlaceIdResponse
+import org.springframework.http.ResponseEntity
+import org.springframework.util.MultiValueMap
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.service.annotation.GetExchange
+
+interface GooglePlaceApiClient {
+    @GetExchange(url = GOOGLE_FIND_PLACE_URL)
+    fun fetchGooglePlaceId(
+        @RequestParam params: MultiValueMap<String, String>,
+    ): GooglePlaceIdResponse
+
+    @GetExchange(url = GOOGLE_PLACE_DETAILS_URL)
+    fun fetchGooglePlaceDetails(
+        @RequestParam params: MultiValueMap<String, String>,
+    ): GooglePlaceDetailsResponse
+
+    @GetExchange(url = GOOGLE_PLACE_PHOTO_URL)
+    fun fetchGooglePlacePhotoUrl(
+        @RequestParam params: MultiValueMap<String, String>,
+    ): ResponseEntity<Void>
+
+    companion object {
+        private const val GOOGLE_FIND_PLACE_URL = "https://maps.googleapis.com/maps/api/place/findplacefromtext/json"
+        private const val GOOGLE_PLACE_DETAILS_URL = "https://maps.googleapis.com/maps/api/place/details/json"
+        private const val GOOGLE_PLACE_PHOTO_URL = "https://maps.googleapis.com/maps/api/place/photo"
+    }
+}

--- a/infrastructure/rest/src/main/kotlin/kr/wooco/woocobe/rest/place/GooglePlaceProperties.kt
+++ b/infrastructure/rest/src/main/kotlin/kr/wooco/woocobe/rest/place/GooglePlaceProperties.kt
@@ -1,0 +1,8 @@
+package kr.wooco.woocobe.rest.place
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties("app.google.place")
+data class GooglePlaceProperties(
+    val apiKey: String,
+)

--- a/infrastructure/rest/src/main/kotlin/kr/wooco/woocobe/rest/place/PlaceClientAdapter.kt
+++ b/infrastructure/rest/src/main/kotlin/kr/wooco/woocobe/rest/place/PlaceClientAdapter.kt
@@ -1,0 +1,56 @@
+package kr.wooco.woocobe.rest.place
+
+import kr.wooco.woocobe.core.place.application.port.out.PlaceClientPort
+import kr.wooco.woocobe.rest.place.response.GooglePlaceDetailsResponse.ResultResponse.PhotoResponse
+import org.springframework.stereotype.Component
+import org.springframework.util.LinkedMultiValueMap
+
+@Component
+internal class PlaceClientAdapter(
+    private val googlePlaceApiClient: GooglePlaceApiClient,
+    private val googlePlaceProperties: GooglePlaceProperties,
+) : PlaceClientPort {
+    override fun fetchPlaceThumbnailUrl(
+        name: String,
+        address: String,
+    ): String? =
+        getFirstGooglePlaceId(name, address)
+            ?.let { getFirstPhotoReference(it) }
+            ?.let { getPhotoUrl(it.width, it.photoReference) }
+
+    private fun getFirstGooglePlaceId(
+        name: String,
+        address: String,
+    ): String? {
+        val params = LinkedMultiValueMap<String, String>().apply {
+            add("input", "$address \"$name\"")
+            add("key", googlePlaceProperties.apiKey)
+            add("inputtype", "textquery")
+        }
+        val response = googlePlaceApiClient.fetchGooglePlaceId(params)
+        return response.candidates.map { it.placeId }.firstOrNull()
+    }
+
+    private fun getFirstPhotoReference(googlePlaceId: String): PhotoResponse? {
+        val params = LinkedMultiValueMap<String, String>().apply {
+            add("placeid", googlePlaceId)
+            add("key", googlePlaceProperties.apiKey)
+            add("language", "ko")
+        }
+        val response = googlePlaceApiClient.fetchGooglePlaceDetails(params)
+        return response.result.photos.firstOrNull()
+    }
+
+    private fun getPhotoUrl(
+        photoWidth: Long,
+        photoReference: String,
+    ): String? {
+        val params = LinkedMultiValueMap<String, String>().apply {
+            add("photo_reference", photoReference)
+            add("key", googlePlaceProperties.apiKey)
+            add("maxwidth", "$photoWidth")
+        }
+        val response = googlePlaceApiClient.fetchGooglePlacePhotoUrl(params)
+        return response.headers.location?.toString()
+    }
+}

--- a/infrastructure/rest/src/main/kotlin/kr/wooco/woocobe/rest/place/response/GooglePlaceDetailsResponse.kt
+++ b/infrastructure/rest/src/main/kotlin/kr/wooco/woocobe/rest/place/response/GooglePlaceDetailsResponse.kt
@@ -1,0 +1,16 @@
+package kr.wooco.woocobe.rest.place.response
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+data class GooglePlaceDetailsResponse(
+    val result: ResultResponse,
+) {
+    data class ResultResponse(
+        val photos: List<PhotoResponse>,
+    ) {
+        data class PhotoResponse(
+            @JsonProperty("photo_reference") val photoReference: String,
+            val width: Long,
+        )
+    }
+}

--- a/infrastructure/rest/src/main/kotlin/kr/wooco/woocobe/rest/place/response/GooglePlaceIdResponse.kt
+++ b/infrastructure/rest/src/main/kotlin/kr/wooco/woocobe/rest/place/response/GooglePlaceIdResponse.kt
@@ -1,0 +1,11 @@
+package kr.wooco.woocobe.rest.place.response
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+data class GooglePlaceIdResponse(
+    val candidates: List<CandidatesResponse>,
+) {
+    data class CandidatesResponse(
+        @JsonProperty("place_id") val placeId: String,
+    )
+}

--- a/infrastructure/rest/src/main/resources/application-rest.yml
+++ b/infrastructure/rest/src/main/resources/application-rest.yml
@@ -5,3 +5,7 @@ app:
       secret-key: ${KAKAO_SECRET_KEY}
       grant-type: ${KAKAO_GRANT_TYPE:authorization_code}
       redirect-uri: ${KAKAO_REDIRECT_URI}
+
+  google:
+    place:
+      api-key: ${GOOGLE_PLACE_API_KEY}


### PR DESCRIPTION
## 📝 개요

<!-- 이 PR의 목적과 관련된 정보를 간략히 설명합니다. -->

구글 PLACE API 를 통해 장소의 썸네일 이미지를 추출합니다.

## ✨ 변경 사항

<!-- 코드나 기능의 주요 변경 사항을 설명 -->

- ✨ 구글 Place API 연동 로직 추가
- ✨ 장소 생성시 이벤트 발행 로직 추가

## 🔗 관련 이슈

<!-- 이 PR과 관련된 이슈 번호를 연결 (없으면 생략) -->

- closed #171 

## ℹ️ 참고 사항

<!-- 리뷰어가 알 필요가 있는 추가 정보나 문서, 참고 링크를 포함 (없으면 생략) -->

- 장소 생성 유즈케이스의 네이밍이 불명확해서 유즈케이스 네이밍을 수정했습니다.
   (`CreatePlaceUseCase` to `CreatePlaceIfNotExistsUseCase`)
- `updatePlaceImage` 에서 외부 API 호출이 물려있어 `@Transactional` 어노테이션을 적용하지 않았습니다.
