### PR TITLE
fix : PlaceReview 에러 수정 및 응답 구조 변경

### DIFF
--- a/bootstrap/api/src/main/kotlin/kr/wooco/woocobe/api/placereview/PlaceReviewApi.kt
+++ b/bootstrap/api/src/main/kotlin/kr/wooco/woocobe/api/placereview/PlaceReviewApi.kt
@@ -5,7 +5,8 @@ import io.swagger.v3.oas.annotations.tags.Tag
 import kr.wooco.woocobe.api.placereview.request.CreatePlaceReviewRequest
 import kr.wooco.woocobe.api.placereview.request.UpdatePlaceReviewRequest
 import kr.wooco.woocobe.api.placereview.response.CreatePlaceReviewResponse
-import kr.wooco.woocobe.api.placereview.response.PlaceReviewDetailsResponse
+import kr.wooco.woocobe.api.placereview.response.PlaceReviewWithPlaceDetailsResponse
+import kr.wooco.woocobe.api.placereview.response.PlaceReviewWithWriterDetailsResponse
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.PathVariable
@@ -15,15 +16,15 @@ import org.springframework.web.bind.annotation.RequestBody
 interface PlaceReviewApi {
     fun getPlaceReviewDetail(
         @PathVariable placeReviewId: Long,
-    ): ResponseEntity<PlaceReviewDetailsResponse>
+    ): ResponseEntity<PlaceReviewWithWriterDetailsResponse>
 
     fun getAllPlaceReview(
         @PathVariable placeId: Long,
-    ): ResponseEntity<List<PlaceReviewDetailsResponse>>
+    ): ResponseEntity<List<PlaceReviewWithWriterDetailsResponse>>
 
     fun getAllMyPlaceReview(
         @PathVariable userId: Long,
-    ): ResponseEntity<List<PlaceReviewDetailsResponse>>
+    ): ResponseEntity<List<PlaceReviewWithPlaceDetailsResponse>>
 
     @SecurityRequirement(name = "JWT")
     fun createPlaceReview(

--- a/bootstrap/api/src/main/kotlin/kr/wooco/woocobe/api/placereview/PlaceReviewApi.kt
+++ b/bootstrap/api/src/main/kotlin/kr/wooco/woocobe/api/placereview/PlaceReviewApi.kt
@@ -22,7 +22,7 @@ interface PlaceReviewApi {
         @PathVariable placeId: Long,
     ): ResponseEntity<List<PlaceReviewWithWriterDetailsResponse>>
 
-    fun getAllMyPlaceReview(
+    fun getAllUserPlaceReview(
         @PathVariable userId: Long,
     ): ResponseEntity<List<PlaceReviewWithPlaceDetailsResponse>>
 

--- a/bootstrap/api/src/main/kotlin/kr/wooco/woocobe/api/placereview/PlaceReviewController.kt
+++ b/bootstrap/api/src/main/kotlin/kr/wooco/woocobe/api/placereview/PlaceReviewController.kt
@@ -86,7 +86,7 @@ class PlaceReviewController(
         @AuthenticationPrincipal userId: Long,
         @PathVariable placeReviewId: Long,
     ): ResponseEntity<Unit> {
-        val command = DeletePlaceReviewUseCase.Command(placeReviewId, userId)
+        val command = DeletePlaceReviewUseCase.Command(userId, placeReviewId)
         deletePlaceReviewUseCase.deletePlaceReview(command)
         return ResponseEntity.ok().build()
     }

--- a/bootstrap/api/src/main/kotlin/kr/wooco/woocobe/api/placereview/PlaceReviewController.kt
+++ b/bootstrap/api/src/main/kotlin/kr/wooco/woocobe/api/placereview/PlaceReviewController.kt
@@ -7,8 +7,8 @@ import kr.wooco.woocobe.api.placereview.response.PlaceReviewWithPlaceDetailsResp
 import kr.wooco.woocobe.api.placereview.response.PlaceReviewWithWriterDetailsResponse
 import kr.wooco.woocobe.core.placereview.application.port.`in`.CreatePlaceReviewUseCase
 import kr.wooco.woocobe.core.placereview.application.port.`in`.DeletePlaceReviewUseCase
-import kr.wooco.woocobe.core.placereview.application.port.`in`.ReadAllMyPlaceReviewUseCase
 import kr.wooco.woocobe.core.placereview.application.port.`in`.ReadAllPlaceReviewUseCase
+import kr.wooco.woocobe.core.placereview.application.port.`in`.ReadAllUserPlaceReviewUseCase
 import kr.wooco.woocobe.core.placereview.application.port.`in`.ReadPlaceReviewUseCase
 import kr.wooco.woocobe.core.placereview.application.port.`in`.UpdatePlaceReviewUseCase
 import org.springframework.http.HttpStatus
@@ -29,7 +29,7 @@ class PlaceReviewController(
     private val createPlaceReviewUseCase: CreatePlaceReviewUseCase,
     private val updatePlaceReviewUseCase: UpdatePlaceReviewUseCase,
     private val deletePlaceReviewUseCase: DeletePlaceReviewUseCase,
-    private val readAllMyPlaceReviewUseCase: ReadAllMyPlaceReviewUseCase,
+    private val readAllUserPlaceReviewUseCase: ReadAllUserPlaceReviewUseCase,
     private val readAllPlaceReviewUseCase: ReadAllPlaceReviewUseCase,
     private val readPlaceReviewUseCase: ReadPlaceReviewUseCase,
 ) : PlaceReviewApi {
@@ -52,11 +52,11 @@ class PlaceReviewController(
     }
 
     @GetMapping("/users/{userId}")
-    override fun getAllMyPlaceReview(
+    override fun getAllUserPlaceReview(
         @PathVariable userId: Long,
     ): ResponseEntity<List<PlaceReviewWithPlaceDetailsResponse>> {
-        val query = ReadAllMyPlaceReviewUseCase.Query(userId)
-        val results = readAllMyPlaceReviewUseCase.readAllMyPlaceReview(query)
+        val query = ReadAllUserPlaceReviewUseCase.Query(userId)
+        val results = readAllUserPlaceReviewUseCase.readAllUserPlaceReview(query)
         return ResponseEntity.ok(PlaceReviewWithPlaceDetailsResponse.listFrom(results))
     }
 

--- a/bootstrap/api/src/main/kotlin/kr/wooco/woocobe/api/placereview/PlaceReviewController.kt
+++ b/bootstrap/api/src/main/kotlin/kr/wooco/woocobe/api/placereview/PlaceReviewController.kt
@@ -3,7 +3,8 @@ package kr.wooco.woocobe.api.placereview
 import kr.wooco.woocobe.api.placereview.request.CreatePlaceReviewRequest
 import kr.wooco.woocobe.api.placereview.request.UpdatePlaceReviewRequest
 import kr.wooco.woocobe.api.placereview.response.CreatePlaceReviewResponse
-import kr.wooco.woocobe.api.placereview.response.PlaceReviewDetailsResponse
+import kr.wooco.woocobe.api.placereview.response.PlaceReviewWithPlaceDetailsResponse
+import kr.wooco.woocobe.api.placereview.response.PlaceReviewWithWriterDetailsResponse
 import kr.wooco.woocobe.core.placereview.application.port.`in`.CreatePlaceReviewUseCase
 import kr.wooco.woocobe.core.placereview.application.port.`in`.DeletePlaceReviewUseCase
 import kr.wooco.woocobe.core.placereview.application.port.`in`.ReadAllMyPlaceReviewUseCase
@@ -35,28 +36,28 @@ class PlaceReviewController(
     @GetMapping("/{placeReviewId}")
     override fun getPlaceReviewDetail(
         @PathVariable placeReviewId: Long,
-    ): ResponseEntity<PlaceReviewDetailsResponse> {
+    ): ResponseEntity<PlaceReviewWithWriterDetailsResponse> {
         val query = ReadPlaceReviewUseCase.Query(placeReviewId)
         val results = readPlaceReviewUseCase.readPlaceReview(query)
-        return ResponseEntity.ok(PlaceReviewDetailsResponse.from(results))
+        return ResponseEntity.ok(PlaceReviewWithWriterDetailsResponse.from(results))
     }
 
     @GetMapping("/places/{placeId}")
     override fun getAllPlaceReview(
         @PathVariable placeId: Long,
-    ): ResponseEntity<List<PlaceReviewDetailsResponse>> {
+    ): ResponseEntity<List<PlaceReviewWithWriterDetailsResponse>> {
         val query = ReadAllPlaceReviewUseCase.Query(placeId)
         val results = readAllPlaceReviewUseCase.readAllPlaceReview(query)
-        return ResponseEntity.ok(PlaceReviewDetailsResponse.listFrom(results))
+        return ResponseEntity.ok(PlaceReviewWithWriterDetailsResponse.listFrom(results))
     }
 
     @GetMapping("/users/{userId}")
     override fun getAllMyPlaceReview(
         @PathVariable userId: Long,
-    ): ResponseEntity<List<PlaceReviewDetailsResponse>> {
+    ): ResponseEntity<List<PlaceReviewWithPlaceDetailsResponse>> {
         val query = ReadAllMyPlaceReviewUseCase.Query(userId)
         val results = readAllMyPlaceReviewUseCase.readAllMyPlaceReview(query)
-        return ResponseEntity.ok(PlaceReviewDetailsResponse.listFrom(results))
+        return ResponseEntity.ok(PlaceReviewWithPlaceDetailsResponse.listFrom(results))
     }
 
     @PostMapping("/places/{placeId}")

--- a/bootstrap/api/src/main/kotlin/kr/wooco/woocobe/api/placereview/response/PlaceReviewDetailsResponse.kt
+++ b/bootstrap/api/src/main/kotlin/kr/wooco/woocobe/api/placereview/response/PlaceReviewDetailsResponse.kt
@@ -10,7 +10,7 @@ data class PlaceReviewDetailsResponse(
     val rating: Double,
     val contents: String,
     val createdAt: LocalDateTime,
-    val oneLineReviews: List<PlaceOneLineReviewResponse>,
+    val oneLineReviews: List<String>,
     val imageUrls: List<String>,
 ) {
     companion object {
@@ -25,10 +25,7 @@ data class PlaceReviewDetailsResponse(
                 rating = placeReviewResult.rating,
                 contents = placeReviewResult.contents,
                 createdAt = placeReviewResult.createdAt,
-                oneLineReviews = placeReviewResult.oneLineReviews
-                    .map { oneLineReview ->
-                        PlaceOneLineReviewResponse.from(oneLineReview)
-                    },
+                oneLineReviews = placeReviewResult.oneLineReviews.map { it.contents },
                 imageUrls = placeReviewResult.reviewImageUrls,
             )
 
@@ -44,24 +41,10 @@ data class PlaceReviewDetailsResponse(
                     rating = it.rating,
                     contents = it.contents,
                     createdAt = it.createdAt,
-                    oneLineReviews = it.oneLineReviews
-                        .map { oneLineReview ->
-                            PlaceOneLineReviewResponse.from(oneLineReview)
-                        },
+                    oneLineReviews = it.oneLineReviews.map { oneLineReview -> oneLineReview.contents },
                     imageUrls = it.reviewImageUrls,
                 )
             }
-    }
-}
-
-data class PlaceOneLineReviewResponse(
-    val contents: String,
-) {
-    companion object {
-        fun from(oneLineReview: PlaceReviewResult.PlaceOneLineReviewResult): PlaceOneLineReviewResponse =
-            PlaceOneLineReviewResponse(
-                contents = oneLineReview.contents,
-            )
     }
 }
 

--- a/bootstrap/api/src/main/kotlin/kr/wooco/woocobe/api/placereview/response/PlaceReviewWithPlaceDetailsResponse.kt
+++ b/bootstrap/api/src/main/kotlin/kr/wooco/woocobe/api/placereview/response/PlaceReviewWithPlaceDetailsResponse.kt
@@ -5,6 +5,7 @@ import java.time.LocalDateTime
 
 data class PlaceReviewWithPlaceDetailsResponse(
     val id: Long,
+    val placeId: Long,
     val placeName: String,
     val rating: Double,
     val contents: String,
@@ -16,8 +17,9 @@ data class PlaceReviewWithPlaceDetailsResponse(
         fun listFrom(placeReviewWithPlaceResults: List<PlaceReviewWithPlaceResult>): List<PlaceReviewWithPlaceDetailsResponse> =
             placeReviewWithPlaceResults.map {
                 PlaceReviewWithPlaceDetailsResponse(
-                    id = it.placeReviewId,
-                    placeName = it.placeName,
+                    id = it.id,
+                    placeId = it.place.id,
+                    placeName = it.place.name,
                     rating = it.rating,
                     contents = it.contents,
                     createdAt = it.createdAt,

--- a/bootstrap/api/src/main/kotlin/kr/wooco/woocobe/api/placereview/response/PlaceReviewWithPlaceDetailsResponse.kt
+++ b/bootstrap/api/src/main/kotlin/kr/wooco/woocobe/api/placereview/response/PlaceReviewWithPlaceDetailsResponse.kt
@@ -1,0 +1,29 @@
+package kr.wooco.woocobe.api.placereview.response
+
+import kr.wooco.woocobe.core.placereview.application.port.`in`.result.PlaceReviewWithPlaceResult
+import java.time.LocalDateTime
+
+data class PlaceReviewWithPlaceDetailsResponse(
+    val id: Long,
+    val placeName: String,
+    val rating: Double,
+    val contents: String,
+    val createdAt: LocalDateTime,
+    val oneLineReviews: List<String>,
+    val imageUrls: List<String>,
+) {
+    companion object {
+        fun listFrom(placeReviewWithPlaceResults: List<PlaceReviewWithPlaceResult>): List<PlaceReviewWithPlaceDetailsResponse> =
+            placeReviewWithPlaceResults.map {
+                PlaceReviewWithPlaceDetailsResponse(
+                    id = it.placeReviewId,
+                    placeName = it.placeName,
+                    rating = it.rating,
+                    contents = it.contents,
+                    createdAt = it.createdAt,
+                    oneLineReviews = it.oneLineReviews.map { oneLineReview -> oneLineReview },
+                    imageUrls = it.reviewImageUrls,
+                )
+            }
+    }
+}

--- a/bootstrap/api/src/main/kotlin/kr/wooco/woocobe/api/placereview/response/PlaceReviewWithWriterDetailsResponse.kt
+++ b/bootstrap/api/src/main/kotlin/kr/wooco/woocobe/api/placereview/response/PlaceReviewWithWriterDetailsResponse.kt
@@ -1,10 +1,10 @@
 package kr.wooco.woocobe.api.placereview.response
 
-import kr.wooco.woocobe.core.placereview.application.port.`in`.result.PlaceReviewResult
+import kr.wooco.woocobe.core.placereview.application.port.`in`.result.PlaceReviewWithWriterResult
 import kr.wooco.woocobe.core.user.domain.entity.User
 import java.time.LocalDateTime
 
-data class PlaceReviewDetailsResponse(
+data class PlaceReviewWithWriterDetailsResponse(
     val id: Long,
     val writer: PlaceReviewWriterResponse,
     val rating: Double,
@@ -14,24 +14,24 @@ data class PlaceReviewDetailsResponse(
     val imageUrls: List<String>,
 ) {
     companion object {
-        fun from(placeReviewResult: PlaceReviewResult): PlaceReviewDetailsResponse =
-            PlaceReviewDetailsResponse(
-                id = placeReviewResult.placeReviewId,
+        fun from(placeReviewWithWriterResult: PlaceReviewWithWriterResult): PlaceReviewWithWriterDetailsResponse =
+            PlaceReviewWithWriterDetailsResponse(
+                id = placeReviewWithWriterResult.placeReviewId,
                 writer = PlaceReviewWriterResponse(
-                    id = placeReviewResult.writerId,
-                    name = placeReviewResult.writerName,
-                    profileUrl = placeReviewResult.writerProfileUrl,
+                    id = placeReviewWithWriterResult.writerId,
+                    name = placeReviewWithWriterResult.writerName,
+                    profileUrl = placeReviewWithWriterResult.writerProfileUrl,
                 ),
-                rating = placeReviewResult.rating,
-                contents = placeReviewResult.contents,
-                createdAt = placeReviewResult.createdAt,
-                oneLineReviews = placeReviewResult.oneLineReviews.map { it.contents },
-                imageUrls = placeReviewResult.reviewImageUrls,
+                rating = placeReviewWithWriterResult.rating,
+                contents = placeReviewWithWriterResult.contents,
+                createdAt = placeReviewWithWriterResult.createdAt,
+                oneLineReviews = placeReviewWithWriterResult.oneLineReviews.map { it },
+                imageUrls = placeReviewWithWriterResult.reviewImageUrls,
             )
 
-        fun listFrom(placeReviewResult: List<PlaceReviewResult>): List<PlaceReviewDetailsResponse> =
-            placeReviewResult.map {
-                PlaceReviewDetailsResponse(
+        fun listFrom(placeReviewWithWriterResults: List<PlaceReviewWithWriterResult>): List<PlaceReviewWithWriterDetailsResponse> =
+            placeReviewWithWriterResults.map {
+                PlaceReviewWithWriterDetailsResponse(
                     id = it.placeReviewId,
                     writer = PlaceReviewWriterResponse(
                         id = it.writerId,
@@ -41,7 +41,7 @@ data class PlaceReviewDetailsResponse(
                     rating = it.rating,
                     contents = it.contents,
                     createdAt = it.createdAt,
-                    oneLineReviews = it.oneLineReviews.map { oneLineReview -> oneLineReview.contents },
+                    oneLineReviews = it.oneLineReviews.map { oneLineReview -> oneLineReview },
                     imageUrls = it.reviewImageUrls,
                 )
             }

--- a/core/src/main/kotlin/kr/wooco/woocobe/core/placereview/application/port/in/ReadAllMyPlaceReviewUseCase.kt
+++ b/core/src/main/kotlin/kr/wooco/woocobe/core/placereview/application/port/in/ReadAllMyPlaceReviewUseCase.kt
@@ -1,11 +1,11 @@
 package kr.wooco.woocobe.core.placereview.application.port.`in`
 
-import kr.wooco.woocobe.core.placereview.application.port.`in`.result.PlaceReviewResult
+import kr.wooco.woocobe.core.placereview.application.port.`in`.result.PlaceReviewWithPlaceResult
 
 fun interface ReadAllMyPlaceReviewUseCase {
     data class Query(
         val userId: Long,
     )
 
-    fun readAllMyPlaceReview(query: Query): List<PlaceReviewResult>
+    fun readAllMyPlaceReview(query: Query): List<PlaceReviewWithPlaceResult>
 }

--- a/core/src/main/kotlin/kr/wooco/woocobe/core/placereview/application/port/in/ReadAllPlaceReviewUseCase.kt
+++ b/core/src/main/kotlin/kr/wooco/woocobe/core/placereview/application/port/in/ReadAllPlaceReviewUseCase.kt
@@ -1,11 +1,11 @@
 package kr.wooco.woocobe.core.placereview.application.port.`in`
 
-import kr.wooco.woocobe.core.placereview.application.port.`in`.result.PlaceReviewResult
+import kr.wooco.woocobe.core.placereview.application.port.`in`.result.PlaceReviewWithWriterResult
 
 fun interface ReadAllPlaceReviewUseCase {
     data class Query(
         val placeId: Long,
     )
 
-    fun readAllPlaceReview(query: Query): List<PlaceReviewResult>
+    fun readAllPlaceReview(query: Query): List<PlaceReviewWithWriterResult>
 }

--- a/core/src/main/kotlin/kr/wooco/woocobe/core/placereview/application/port/in/ReadAllUserPlaceReviewUseCase.kt
+++ b/core/src/main/kotlin/kr/wooco/woocobe/core/placereview/application/port/in/ReadAllUserPlaceReviewUseCase.kt
@@ -2,10 +2,10 @@ package kr.wooco.woocobe.core.placereview.application.port.`in`
 
 import kr.wooco.woocobe.core.placereview.application.port.`in`.result.PlaceReviewWithPlaceResult
 
-fun interface ReadAllMyPlaceReviewUseCase {
+fun interface ReadAllUserPlaceReviewUseCase {
     data class Query(
         val userId: Long,
     )
 
-    fun readAllMyPlaceReview(query: Query): List<PlaceReviewWithPlaceResult>
+    fun readAllUserPlaceReview(query: Query): List<PlaceReviewWithPlaceResult>
 }

--- a/core/src/main/kotlin/kr/wooco/woocobe/core/placereview/application/port/in/ReadPlaceReviewUseCase.kt
+++ b/core/src/main/kotlin/kr/wooco/woocobe/core/placereview/application/port/in/ReadPlaceReviewUseCase.kt
@@ -1,11 +1,11 @@
 package kr.wooco.woocobe.core.placereview.application.port.`in`
 
-import kr.wooco.woocobe.core.placereview.application.port.`in`.result.PlaceReviewResult
+import kr.wooco.woocobe.core.placereview.application.port.`in`.result.PlaceReviewWithWriterResult
 
 fun interface ReadPlaceReviewUseCase {
     data class Query(
         val placeReviewId: Long,
     )
 
-    fun readPlaceReview(query: Query): PlaceReviewResult
+    fun readPlaceReview(query: Query): PlaceReviewWithWriterResult
 }

--- a/core/src/main/kotlin/kr/wooco/woocobe/core/placereview/application/port/in/result/PlaceReviewWithPlaceResult.kt
+++ b/core/src/main/kotlin/kr/wooco/woocobe/core/placereview/application/port/in/result/PlaceReviewWithPlaceResult.kt
@@ -3,26 +3,26 @@ package kr.wooco.woocobe.core.placereview.application.port.`in`.result
 import kr.wooco.woocobe.core.place.domain.entity.Place
 import kr.wooco.woocobe.core.placereview.domain.entity.PlaceOneLineReview
 import kr.wooco.woocobe.core.placereview.domain.entity.PlaceReview
-import kr.wooco.woocobe.core.user.domain.entity.User
 import java.time.LocalDateTime
 
 data class PlaceReviewWithPlaceResult(
-    val placeReviewId: Long,
-    val placeName: String,
-    val writerId: Long,
-    val writerName: String,
-    val writerProfileUrl: String,
+    val id: Long,
+    val place: PlaceResult,
     val contents: String,
     val rating: Double,
     val oneLineReviews: List<String>,
     val reviewImageUrls: List<String>,
     val createdAt: LocalDateTime,
 ) {
+    data class PlaceResult(
+        val id: Long,
+        val name: String,
+    )
+
     companion object {
         fun listOf(
             placeReviews: List<PlaceReview>,
             placeOneLineReviews: List<PlaceOneLineReview>,
-            writer: User,
             places: List<Place>,
         ): List<PlaceReviewWithPlaceResult> {
             val oneLineReviewsMap = placeOneLineReviews.groupBy { it.placeReviewId }
@@ -33,11 +33,11 @@ data class PlaceReviewWithPlaceResult(
                 val place = placeMap[placeReview.placeId]!!
 
                 PlaceReviewWithPlaceResult(
-                    placeReviewId = placeReview.id,
-                    placeName = place.name,
-                    writerId = writer.id,
-                    writerName = writer.profile.name,
-                    writerProfileUrl = writer.profile.profileUrl,
+                    id = placeReview.id,
+                    place = PlaceResult(
+                        id = place.id,
+                        name = place.name,
+                    ),
                     contents = placeReview.contents,
                     rating = placeReview.rating,
                     oneLineReviews = oneLineReviews.map { it.contents.value },

--- a/core/src/main/kotlin/kr/wooco/woocobe/core/placereview/application/port/in/result/PlaceReviewWithPlaceResult.kt
+++ b/core/src/main/kotlin/kr/wooco/woocobe/core/placereview/application/port/in/result/PlaceReviewWithPlaceResult.kt
@@ -1,0 +1,50 @@
+package kr.wooco.woocobe.core.placereview.application.port.`in`.result
+
+import kr.wooco.woocobe.core.place.domain.entity.Place
+import kr.wooco.woocobe.core.placereview.domain.entity.PlaceOneLineReview
+import kr.wooco.woocobe.core.placereview.domain.entity.PlaceReview
+import kr.wooco.woocobe.core.user.domain.entity.User
+import java.time.LocalDateTime
+
+data class PlaceReviewWithPlaceResult(
+    val placeReviewId: Long,
+    val placeName: String,
+    val writerId: Long,
+    val writerName: String,
+    val writerProfileUrl: String,
+    val contents: String,
+    val rating: Double,
+    val oneLineReviews: List<String>,
+    val reviewImageUrls: List<String>,
+    val createdAt: LocalDateTime,
+) {
+    companion object {
+        fun listOf(
+            placeReviews: List<PlaceReview>,
+            placeOneLineReviews: List<PlaceOneLineReview>,
+            writer: User,
+            places: List<Place>,
+        ): List<PlaceReviewWithPlaceResult> {
+            val oneLineReviewsMap = placeOneLineReviews.groupBy { it.placeReviewId }
+            val placeMap = places.associateBy { it.id }
+
+            return placeReviews.map { placeReview ->
+                val oneLineReviews = oneLineReviewsMap[placeReview.id] ?: emptyList()
+                val place = placeMap[placeReview.placeId]!!
+
+                PlaceReviewWithPlaceResult(
+                    placeReviewId = placeReview.id,
+                    placeName = place.name,
+                    writerId = writer.id,
+                    writerName = writer.profile.name,
+                    writerProfileUrl = writer.profile.profileUrl,
+                    contents = placeReview.contents,
+                    rating = placeReview.rating,
+                    oneLineReviews = oneLineReviews.map { it.contents.value },
+                    reviewImageUrls = placeReview.imageUrls,
+                    createdAt = placeReview.writeDateTime,
+                )
+            }
+        }
+    }
+}

--- a/core/src/main/kotlin/kr/wooco/woocobe/core/placereview/application/port/in/result/PlaceReviewWithWriterResult.kt
+++ b/core/src/main/kotlin/kr/wooco/woocobe/core/placereview/application/port/in/result/PlaceReviewWithWriterResult.kt
@@ -5,14 +5,14 @@ import kr.wooco.woocobe.core.placereview.domain.entity.PlaceReview
 import kr.wooco.woocobe.core.user.domain.entity.User
 import java.time.LocalDateTime
 
-data class PlaceReviewResult(
+data class PlaceReviewWithWriterResult(
     val placeReviewId: Long,
     val writerId: Long,
     val writerName: String,
     val writerProfileUrl: String,
     val contents: String,
     val rating: Double,
-    val oneLineReviews: List<PlaceOneLineReviewResult>,
+    val oneLineReviews: List<String>,
     val reviewImageUrls: List<String>,
     val createdAt: LocalDateTime,
 ) {
@@ -21,15 +21,15 @@ data class PlaceReviewResult(
             placeReview: PlaceReview,
             placeOneLineReviews: List<PlaceOneLineReview>,
             user: User,
-        ): PlaceReviewResult =
-            PlaceReviewResult(
+        ): PlaceReviewWithWriterResult =
+            PlaceReviewWithWriterResult(
                 placeReviewId = placeReview.id,
                 writerId = user.id,
                 writerName = user.profile.name,
                 writerProfileUrl = user.profile.profileUrl,
                 contents = placeReview.contents,
                 rating = placeReview.rating,
-                oneLineReviews = PlaceOneLineReviewResult.listFrom(placeOneLineReviews),
+                oneLineReviews = placeOneLineReviews.map { it.contents.value },
                 reviewImageUrls = placeReview.imageUrls,
                 createdAt = placeReview.writeDateTime,
             )
@@ -38,39 +38,24 @@ data class PlaceReviewResult(
             placeReviews: List<PlaceReview>,
             placeOneLineReviews: List<PlaceOneLineReview>,
             writers: List<User>,
-        ): List<PlaceReviewResult> {
+        ): List<PlaceReviewWithWriterResult> {
             val writerMap = writers.associateBy { it.id }
             val oneLineReviewsMap = placeOneLineReviews.groupBy { it.placeReviewId }
-
             return placeReviews.map { placeReview ->
                 val writer = writerMap[placeReview.userId]!!
                 val oneLineReviews = oneLineReviewsMap[placeReview.id] ?: emptyList()
-
-                PlaceReviewResult(
+                PlaceReviewWithWriterResult(
                     placeReviewId = placeReview.id,
                     writerId = writer.id,
                     writerName = writer.profile.name,
                     writerProfileUrl = writer.profile.profileUrl,
                     contents = placeReview.contents,
                     rating = placeReview.rating,
-                    oneLineReviews = PlaceOneLineReviewResult.listFrom(oneLineReviews),
+                    oneLineReviews = oneLineReviews.map { it.contents.value },
                     reviewImageUrls = placeReview.imageUrls,
                     createdAt = placeReview.writeDateTime,
                 )
             }
-        }
-    }
-
-    data class PlaceOneLineReviewResult(
-        val contents: String,
-    ) {
-        companion object {
-            fun listFrom(contents: List<PlaceOneLineReview>): List<PlaceOneLineReviewResult> =
-                contents.map {
-                    PlaceOneLineReviewResult(
-                        contents = it.contents.value,
-                    )
-                }
         }
     }
 }

--- a/core/src/main/kotlin/kr/wooco/woocobe/core/placereview/application/port/out/LoadPlaceReviewPersistencePort.kt
+++ b/core/src/main/kotlin/kr/wooco/woocobe/core/placereview/application/port/out/LoadPlaceReviewPersistencePort.kt
@@ -8,6 +8,4 @@ interface LoadPlaceReviewPersistencePort {
     fun getAllByPlaceId(placeId: Long): List<PlaceReview>
 
     fun getAllByUserId(userId: Long): List<PlaceReview>
-
-    fun getAllByPlaceReviewIds(placeReviewIds: List<Long>): List<PlaceReview>
 }

--- a/core/src/main/kotlin/kr/wooco/woocobe/core/placereview/application/service/PlaceReviewCommandService.kt
+++ b/core/src/main/kotlin/kr/wooco/woocobe/core/placereview/application/service/PlaceReviewCommandService.kt
@@ -83,6 +83,6 @@ class PlaceReviewCommandService(
         deleteAllPlaceOneLineReviewPersistencePort.deleteAllByPlaceReviewId(placeReview.id)
         deletePlaceReviewPersistencePort.deletePlaceReviewId(command.placeReviewId)
 
-        eventPublisher.publishEvent(PlaceReviewDeleteEvent.of(placeReview))
+        eventPublisher.publishEvent(PlaceReviewDeleteEvent.from(placeReview))
     }
 }

--- a/core/src/main/kotlin/kr/wooco/woocobe/core/placereview/application/service/PlaceReviewCommandService.kt
+++ b/core/src/main/kotlin/kr/wooco/woocobe/core/placereview/application/service/PlaceReviewCommandService.kt
@@ -48,19 +48,13 @@ class PlaceReviewCommandService(
         }
         saveAllPlaceOneLineReviewPersistencePort.saveAllPlaceOneLineReview(placeOneLineReviews)
 
-        eventPublisher.publishEvent(
-            PlaceReviewCreateEvent(
-                placeId = placeReview.placeId,
-                rating = placeReview.rating,
-            ),
-        )
+        eventPublisher.publishEvent(PlaceReviewCreateEvent.from(placeReview))
         return placeReview.id
     }
 
     @Transactional
     override fun updatePlaceReview(command: UpdatePlaceReviewUseCase.Command) {
         val placeReview = loadPlaceReviewPersistencePort.getByPlaceReviewId(command.placeReviewId)
-
         placeReview.update(
             userId = command.userId,
             rating = command.rating,
@@ -79,13 +73,7 @@ class PlaceReviewCommandService(
         }
         saveAllPlaceOneLineReviewPersistencePort.saveAllPlaceOneLineReview(placeOneLineReviews)
 
-        eventPublisher.publishEvent(
-            PlaceReviewUpdateEvent(
-                placeId = placeReview.placeId,
-                oldRating = placeReview.rating,
-                newRating = command.rating,
-            ),
-        )
+        eventPublisher.publishEvent(PlaceReviewUpdateEvent.of(placeReview, command))
     }
 
     @Transactional
@@ -95,11 +83,6 @@ class PlaceReviewCommandService(
         deleteAllPlaceOneLineReviewPersistencePort.deleteAllByPlaceReviewId(placeReview.id)
         deletePlaceReviewPersistencePort.deletePlaceReviewId(command.placeReviewId)
 
-        eventPublisher.publishEvent(
-            PlaceReviewDeleteEvent(
-                placeReview.placeId,
-                placeReview.rating,
-            ),
-        )
+        eventPublisher.publishEvent(PlaceReviewDeleteEvent.of(placeReview))
     }
 }

--- a/core/src/main/kotlin/kr/wooco/woocobe/core/placereview/application/service/PlaceReviewQueryService.kt
+++ b/core/src/main/kotlin/kr/wooco/woocobe/core/placereview/application/service/PlaceReviewQueryService.kt
@@ -1,9 +1,11 @@
 package kr.wooco.woocobe.core.placereview.application.service
 
+import kr.wooco.woocobe.core.place.application.port.out.LoadPlacePersistencePort
 import kr.wooco.woocobe.core.placereview.application.port.`in`.ReadAllMyPlaceReviewUseCase
 import kr.wooco.woocobe.core.placereview.application.port.`in`.ReadAllPlaceReviewUseCase
 import kr.wooco.woocobe.core.placereview.application.port.`in`.ReadPlaceReviewUseCase
-import kr.wooco.woocobe.core.placereview.application.port.`in`.result.PlaceReviewResult
+import kr.wooco.woocobe.core.placereview.application.port.`in`.result.PlaceReviewWithPlaceResult
+import kr.wooco.woocobe.core.placereview.application.port.`in`.result.PlaceReviewWithWriterResult
 import kr.wooco.woocobe.core.placereview.application.port.out.LoadPlaceOneLineReviewPersistencePort
 import kr.wooco.woocobe.core.placereview.application.port.out.LoadPlaceReviewPersistencePort
 import kr.wooco.woocobe.core.user.application.port.out.LoadUserPersistencePort
@@ -15,34 +17,36 @@ internal class PlaceReviewQueryService(
     private val loadUserPersistencePort: LoadUserPersistencePort,
     private val loadPlaceReviewPersistencePort: LoadPlaceReviewPersistencePort,
     private val loadPlaceOneLineReviewPersistencePort: LoadPlaceOneLineReviewPersistencePort,
+    private val loadPlacePersistencePort: LoadPlacePersistencePort,
 ) : ReadAllPlaceReviewUseCase,
     ReadAllMyPlaceReviewUseCase,
     ReadPlaceReviewUseCase {
     @Transactional(readOnly = true)
-    override fun readAllPlaceReview(query: ReadAllPlaceReviewUseCase.Query): List<PlaceReviewResult> {
+    override fun readAllPlaceReview(query: ReadAllPlaceReviewUseCase.Query): List<PlaceReviewWithWriterResult> {
         val placeReviews = loadPlaceReviewPersistencePort.getAllByPlaceId(query.placeId)
         val placeOneLineReviews =
             loadPlaceOneLineReviewPersistencePort.getAllByPlaceReviewIds(placeReviews.map { it.id })
         val writerIds = placeReviews.map { it.userId }.distinct()
         val writers = loadUserPersistencePort.getAllByUserIds(writerIds)
-        return PlaceReviewResult.listOf(placeReviews, placeOneLineReviews, writers)
+        return PlaceReviewWithWriterResult.listOf(placeReviews, placeOneLineReviews, writers)
     }
 
     @Transactional(readOnly = true)
-    override fun readAllMyPlaceReview(query: ReadAllMyPlaceReviewUseCase.Query): List<PlaceReviewResult> {
+    override fun readAllMyPlaceReview(query: ReadAllMyPlaceReviewUseCase.Query): List<PlaceReviewWithPlaceResult> {
         val placeReviews = loadPlaceReviewPersistencePort.getAllByUserId(query.userId)
         val placeOneLineReviews =
             loadPlaceOneLineReviewPersistencePort.getAllByPlaceReviewIds(placeReviews.map { it.id })
-        val writerIds = placeReviews.map { it.userId }.distinct()
-        val writers = loadUserPersistencePort.getAllByUserIds(writerIds)
-        return PlaceReviewResult.listOf(placeReviews, placeOneLineReviews, writers)
+        val placeIds = placeReviews.map { it.placeId }.distinct()
+        val places = loadPlacePersistencePort.getAllByPlaceIds(placeIds)
+        val writer = loadUserPersistencePort.getByUserId(query.userId)
+        return PlaceReviewWithPlaceResult.listOf(placeReviews, placeOneLineReviews, writer, places)
     }
 
     @Transactional(readOnly = true)
-    override fun readPlaceReview(query: ReadPlaceReviewUseCase.Query): PlaceReviewResult {
+    override fun readPlaceReview(query: ReadPlaceReviewUseCase.Query): PlaceReviewWithWriterResult {
         val placeReview = loadPlaceReviewPersistencePort.getByPlaceReviewId(query.placeReviewId)
         val placeOneLineReviews = loadPlaceOneLineReviewPersistencePort.getAllByPlaceReviewId(placeReview.id)
         val writer = loadUserPersistencePort.getByUserId(placeReview.userId)
-        return PlaceReviewResult.of(placeReview, placeOneLineReviews, writer)
+        return PlaceReviewWithWriterResult.of(placeReview, placeOneLineReviews, writer)
     }
 }

--- a/core/src/main/kotlin/kr/wooco/woocobe/core/placereview/application/service/PlaceReviewQueryService.kt
+++ b/core/src/main/kotlin/kr/wooco/woocobe/core/placereview/application/service/PlaceReviewQueryService.kt
@@ -38,8 +38,7 @@ internal class PlaceReviewQueryService(
             loadPlaceOneLineReviewPersistencePort.getAllByPlaceReviewIds(placeReviews.map { it.id })
         val placeIds = placeReviews.map { it.placeId }.distinct()
         val places = loadPlacePersistencePort.getAllByPlaceIds(placeIds)
-        val writer = loadUserPersistencePort.getByUserId(query.userId)
-        return PlaceReviewWithPlaceResult.listOf(placeReviews, placeOneLineReviews, writer, places)
+        return PlaceReviewWithPlaceResult.listOf(placeReviews, placeOneLineReviews, places)
     }
 
     @Transactional(readOnly = true)

--- a/core/src/main/kotlin/kr/wooco/woocobe/core/placereview/application/service/PlaceReviewQueryService.kt
+++ b/core/src/main/kotlin/kr/wooco/woocobe/core/placereview/application/service/PlaceReviewQueryService.kt
@@ -1,8 +1,8 @@
 package kr.wooco.woocobe.core.placereview.application.service
 
 import kr.wooco.woocobe.core.place.application.port.out.LoadPlacePersistencePort
-import kr.wooco.woocobe.core.placereview.application.port.`in`.ReadAllMyPlaceReviewUseCase
 import kr.wooco.woocobe.core.placereview.application.port.`in`.ReadAllPlaceReviewUseCase
+import kr.wooco.woocobe.core.placereview.application.port.`in`.ReadAllUserPlaceReviewUseCase
 import kr.wooco.woocobe.core.placereview.application.port.`in`.ReadPlaceReviewUseCase
 import kr.wooco.woocobe.core.placereview.application.port.`in`.result.PlaceReviewWithPlaceResult
 import kr.wooco.woocobe.core.placereview.application.port.`in`.result.PlaceReviewWithWriterResult
@@ -19,7 +19,7 @@ internal class PlaceReviewQueryService(
     private val loadPlaceOneLineReviewPersistencePort: LoadPlaceOneLineReviewPersistencePort,
     private val loadPlacePersistencePort: LoadPlacePersistencePort,
 ) : ReadAllPlaceReviewUseCase,
-    ReadAllMyPlaceReviewUseCase,
+    ReadAllUserPlaceReviewUseCase,
     ReadPlaceReviewUseCase {
     @Transactional(readOnly = true)
     override fun readAllPlaceReview(query: ReadAllPlaceReviewUseCase.Query): List<PlaceReviewWithWriterResult> {
@@ -32,7 +32,7 @@ internal class PlaceReviewQueryService(
     }
 
     @Transactional(readOnly = true)
-    override fun readAllMyPlaceReview(query: ReadAllMyPlaceReviewUseCase.Query): List<PlaceReviewWithPlaceResult> {
+    override fun readAllUserPlaceReview(query: ReadAllUserPlaceReviewUseCase.Query): List<PlaceReviewWithPlaceResult> {
         val placeReviews = loadPlaceReviewPersistencePort.getAllByUserId(query.userId)
         val placeOneLineReviews =
             loadPlaceOneLineReviewPersistencePort.getAllByPlaceReviewIds(placeReviews.map { it.id })

--- a/core/src/main/kotlin/kr/wooco/woocobe/core/placereview/domain/entity/PlaceReview.kt
+++ b/core/src/main/kotlin/kr/wooco/woocobe/core/placereview/domain/entity/PlaceReview.kt
@@ -12,6 +12,10 @@ data class PlaceReview(
     val contents: String,
     val imageUrls: List<String>,
 ) {
+    init {
+        require(rating in 1.0..5.0) { "평점은 1.0 ~ 5.0 사이여야 합니다." }
+    }
+
     fun update(
         userId: Long,
         rating: Double,

--- a/core/src/main/kotlin/kr/wooco/woocobe/core/placereview/domain/event/PlaceReviewCreateEvent.kt
+++ b/core/src/main/kotlin/kr/wooco/woocobe/core/placereview/domain/event/PlaceReviewCreateEvent.kt
@@ -9,7 +9,7 @@ data class PlaceReviewCreateEvent(
     companion object {
         fun from(placeReview: PlaceReview): PlaceReviewCreateEvent =
             PlaceReviewCreateEvent(
-                placeId = placeReview.id,
+                placeId = placeReview.placeId,
                 rating = placeReview.rating,
             )
     }

--- a/core/src/main/kotlin/kr/wooco/woocobe/core/placereview/domain/event/PlaceReviewCreateEvent.kt
+++ b/core/src/main/kotlin/kr/wooco/woocobe/core/placereview/domain/event/PlaceReviewCreateEvent.kt
@@ -3,4 +3,15 @@ package kr.wooco.woocobe.core.placereview.domain.event
 data class PlaceReviewCreateEvent(
     val placeId: Long,
     val rating: Double,
-)
+) {
+    companion object {
+        fun of(
+            placeId: Long,
+            rating: Double,
+        ): PlaceReviewCreateEvent =
+            PlaceReviewCreateEvent(
+                placeId = placeId,
+                rating = rating,
+            )
+    }
+}

--- a/core/src/main/kotlin/kr/wooco/woocobe/core/placereview/domain/event/PlaceReviewCreateEvent.kt
+++ b/core/src/main/kotlin/kr/wooco/woocobe/core/placereview/domain/event/PlaceReviewCreateEvent.kt
@@ -1,17 +1,16 @@
 package kr.wooco.woocobe.core.placereview.domain.event
 
+import kr.wooco.woocobe.core.placereview.domain.entity.PlaceReview
+
 data class PlaceReviewCreateEvent(
     val placeId: Long,
     val rating: Double,
 ) {
     companion object {
-        fun of(
-            placeId: Long,
-            rating: Double,
-        ): PlaceReviewCreateEvent =
+        fun from(placeReview: PlaceReview): PlaceReviewCreateEvent =
             PlaceReviewCreateEvent(
-                placeId = placeId,
-                rating = rating,
+                placeId = placeReview.id,
+                rating = placeReview.rating,
             )
     }
 }

--- a/core/src/main/kotlin/kr/wooco/woocobe/core/placereview/domain/event/PlaceReviewDeleteEvent.kt
+++ b/core/src/main/kotlin/kr/wooco/woocobe/core/placereview/domain/event/PlaceReviewDeleteEvent.kt
@@ -1,17 +1,16 @@
 package kr.wooco.woocobe.core.placereview.domain.event
 
+import kr.wooco.woocobe.core.placereview.domain.entity.PlaceReview
+
 data class PlaceReviewDeleteEvent(
     val placeId: Long,
     val rating: Double,
 ) {
     companion object {
-        fun of(
-            placeId: Long,
-            rating: Double,
-        ): PlaceReviewDeleteEvent =
+        fun of(placeReview: PlaceReview): PlaceReviewDeleteEvent =
             PlaceReviewDeleteEvent(
-                placeId = placeId,
-                rating = rating,
+                placeId = placeReview.id,
+                rating = placeReview.rating,
             )
     }
 }

--- a/core/src/main/kotlin/kr/wooco/woocobe/core/placereview/domain/event/PlaceReviewDeleteEvent.kt
+++ b/core/src/main/kotlin/kr/wooco/woocobe/core/placereview/domain/event/PlaceReviewDeleteEvent.kt
@@ -3,4 +3,15 @@ package kr.wooco.woocobe.core.placereview.domain.event
 data class PlaceReviewDeleteEvent(
     val placeId: Long,
     val rating: Double,
-)
+) {
+    companion object {
+        fun of(
+            placeId: Long,
+            rating: Double,
+        ): PlaceReviewDeleteEvent =
+            PlaceReviewDeleteEvent(
+                placeId = placeId,
+                rating = rating,
+            )
+    }
+}

--- a/core/src/main/kotlin/kr/wooco/woocobe/core/placereview/domain/event/PlaceReviewDeleteEvent.kt
+++ b/core/src/main/kotlin/kr/wooco/woocobe/core/placereview/domain/event/PlaceReviewDeleteEvent.kt
@@ -9,7 +9,7 @@ data class PlaceReviewDeleteEvent(
     companion object {
         fun of(placeReview: PlaceReview): PlaceReviewDeleteEvent =
             PlaceReviewDeleteEvent(
-                placeId = placeReview.id,
+                placeId = placeReview.placeId,
                 rating = placeReview.rating,
             )
     }

--- a/core/src/main/kotlin/kr/wooco/woocobe/core/placereview/domain/event/PlaceReviewDeleteEvent.kt
+++ b/core/src/main/kotlin/kr/wooco/woocobe/core/placereview/domain/event/PlaceReviewDeleteEvent.kt
@@ -7,7 +7,7 @@ data class PlaceReviewDeleteEvent(
     val rating: Double,
 ) {
     companion object {
-        fun of(placeReview: PlaceReview): PlaceReviewDeleteEvent =
+        fun from(placeReview: PlaceReview): PlaceReviewDeleteEvent =
             PlaceReviewDeleteEvent(
                 placeId = placeReview.placeId,
                 rating = placeReview.rating,

--- a/core/src/main/kotlin/kr/wooco/woocobe/core/placereview/domain/event/PlaceReviewUpdateEvent.kt
+++ b/core/src/main/kotlin/kr/wooco/woocobe/core/placereview/domain/event/PlaceReviewUpdateEvent.kt
@@ -14,7 +14,7 @@ data class PlaceReviewUpdateEvent(
             command: UpdatePlaceReviewUseCase.Command,
         ): PlaceReviewUpdateEvent =
             PlaceReviewUpdateEvent(
-                placeId = placeReview.id,
+                placeId = placeReview.placeId,
                 oldRating = placeReview.rating,
                 newRating = command.rating,
             )

--- a/core/src/main/kotlin/kr/wooco/woocobe/core/placereview/domain/event/PlaceReviewUpdateEvent.kt
+++ b/core/src/main/kotlin/kr/wooco/woocobe/core/placereview/domain/event/PlaceReviewUpdateEvent.kt
@@ -4,4 +4,17 @@ data class PlaceReviewUpdateEvent(
     val placeId: Long,
     val oldRating: Double,
     val newRating: Double,
-)
+) {
+    companion object {
+        fun of(
+            placeId: Long,
+            oldRating: Double,
+            newRating: Double,
+        ): PlaceReviewUpdateEvent =
+            PlaceReviewUpdateEvent(
+                placeId = placeId,
+                oldRating = oldRating,
+                newRating = newRating,
+            )
+    }
+}

--- a/core/src/main/kotlin/kr/wooco/woocobe/core/placereview/domain/event/PlaceReviewUpdateEvent.kt
+++ b/core/src/main/kotlin/kr/wooco/woocobe/core/placereview/domain/event/PlaceReviewUpdateEvent.kt
@@ -1,5 +1,8 @@
 package kr.wooco.woocobe.core.placereview.domain.event
 
+import kr.wooco.woocobe.core.placereview.application.port.`in`.UpdatePlaceReviewUseCase
+import kr.wooco.woocobe.core.placereview.domain.entity.PlaceReview
+
 data class PlaceReviewUpdateEvent(
     val placeId: Long,
     val oldRating: Double,
@@ -7,14 +10,13 @@ data class PlaceReviewUpdateEvent(
 ) {
     companion object {
         fun of(
-            placeId: Long,
-            oldRating: Double,
-            newRating: Double,
+            placeReview: PlaceReview,
+            command: UpdatePlaceReviewUseCase.Command,
         ): PlaceReviewUpdateEvent =
             PlaceReviewUpdateEvent(
-                placeId = placeId,
-                oldRating = oldRating,
-                newRating = newRating,
+                placeId = placeReview.id,
+                oldRating = placeReview.rating,
+                newRating = command.rating,
             )
     }
 }

--- a/infrastructure/mysql/src/main/kotlin/kr/wooco/woocobe/mysql/placereview/PlaceReviewPersistenceAdapter.kt
+++ b/infrastructure/mysql/src/main/kotlin/kr/wooco/woocobe/mysql/placereview/PlaceReviewPersistenceAdapter.kt
@@ -19,7 +19,6 @@ internal class PlaceReviewPersistenceAdapter(
 ) : SavePlaceReviewPersistencePort,
     LoadPlaceReviewPersistencePort,
     DeletePlaceReviewPersistencePort {
-    // TODO: 최대 이미지 갯수 제한
     override fun savePlaceReview(placeReview: PlaceReview): PlaceReview {
         val placeReviewEntity = placeReviewPersistenceMapper.toEntity(placeReview)
         placeReviewJpaRepository.save(placeReviewEntity)

--- a/infrastructure/mysql/src/main/kotlin/kr/wooco/woocobe/mysql/placereview/PlaceReviewPersistenceAdapter.kt
+++ b/infrastructure/mysql/src/main/kotlin/kr/wooco/woocobe/mysql/placereview/PlaceReviewPersistenceAdapter.kt
@@ -12,7 +12,6 @@ import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Component
 
 @Component
-@Suppress("Duplicates")
 internal class PlaceReviewPersistenceAdapter(
     private val placeReviewJpaRepository: PlaceReviewJpaRepository,
     private val placeReviewImageJpaRepository: PlaceReviewImageJpaRepository,

--- a/infrastructure/mysql/src/main/kotlin/kr/wooco/woocobe/mysql/placereview/PlaceReviewPersistenceAdapter.kt
+++ b/infrastructure/mysql/src/main/kotlin/kr/wooco/woocobe/mysql/placereview/PlaceReviewPersistenceAdapter.kt
@@ -30,6 +30,8 @@ internal class PlaceReviewPersistenceAdapter(
                 imageUrl = it,
             )
         }
+        placeReviewImageJpaRepository.saveAll(placeReviewImageEntities)
+
         return placeReviewPersistenceMapper.toDomain(
             placeReviewEntity,
             placeReviewImageEntities,
@@ -48,6 +50,7 @@ internal class PlaceReviewPersistenceAdapter(
         )
     }
 
+    // 지우기
     override fun getAllByPlaceReviewIds(placeReviewIds: List<Long>): List<PlaceReview> {
         val placeReviewEntities = placeReviewJpaRepository
             .findAllByIdInOrderByCreatedAt(placeReviewIds)

--- a/infrastructure/mysql/src/main/kotlin/kr/wooco/woocobe/mysql/placereview/PlaceReviewPersistenceAdapter.kt
+++ b/infrastructure/mysql/src/main/kotlin/kr/wooco/woocobe/mysql/placereview/PlaceReviewPersistenceAdapter.kt
@@ -20,10 +20,10 @@ internal class PlaceReviewPersistenceAdapter(
 ) : SavePlaceReviewPersistencePort,
     LoadPlaceReviewPersistencePort,
     DeletePlaceReviewPersistencePort {
+    // TODO: 최대 이미지 갯수 제한
     override fun savePlaceReview(placeReview: PlaceReview): PlaceReview {
         val placeReviewEntity = placeReviewPersistenceMapper.toEntity(placeReview)
         placeReviewJpaRepository.save(placeReviewEntity)
-
         val placeReviewImageEntities = placeReview.imageUrls.map {
             PlaceReviewImageJpaEntity(
                 placeReviewId = placeReviewEntity.id,
@@ -31,7 +31,6 @@ internal class PlaceReviewPersistenceAdapter(
             )
         }
         placeReviewImageJpaRepository.saveAll(placeReviewImageEntities)
-
         return placeReviewPersistenceMapper.toDomain(
             placeReviewEntity,
             placeReviewImageEntities,
@@ -43,7 +42,6 @@ internal class PlaceReviewPersistenceAdapter(
             ?: throw NotExistsPlaceReviewException
         val placeReviewImageEntities = placeReviewImageJpaRepository
             .findAllByPlaceReviewId(placeReviewEntity.id)
-
         return placeReviewPersistenceMapper.toDomain(
             placeReviewEntity,
             placeReviewImageEntities,
@@ -54,7 +52,6 @@ internal class PlaceReviewPersistenceAdapter(
         val placeReviewEntities = placeReviewJpaRepository.findAllByPlaceIdOrderByCreatedAt(placeId)
         val placeReviewImageEntities = placeReviewImageJpaRepository
             .findAllByPlaceReviewIdIn(placeReviewEntities.map { it.id })
-
         return placeReviewEntities.map { placeReviewEntity ->
             placeReviewPersistenceMapper.toDomain(
                 placeReviewJpaEntity = placeReviewEntity,
@@ -68,7 +65,6 @@ internal class PlaceReviewPersistenceAdapter(
         val placeReviewEntities = placeReviewJpaRepository.findAllByUserIdOrderByCreatedAt(userId)
         val placeReviewImageEntities = placeReviewImageJpaRepository
             .findAllByPlaceReviewIdIn(placeReviewEntities.map { it.id })
-
         return placeReviewEntities.map { placeReviewEntity ->
             placeReviewPersistenceMapper.toDomain(
                 placeReviewJpaEntity = placeReviewEntity,

--- a/infrastructure/mysql/src/main/kotlin/kr/wooco/woocobe/mysql/placereview/PlaceReviewPersistenceAdapter.kt
+++ b/infrastructure/mysql/src/main/kotlin/kr/wooco/woocobe/mysql/placereview/PlaceReviewPersistenceAdapter.kt
@@ -50,22 +50,6 @@ internal class PlaceReviewPersistenceAdapter(
         )
     }
 
-    // 지우기
-    override fun getAllByPlaceReviewIds(placeReviewIds: List<Long>): List<PlaceReview> {
-        val placeReviewEntities = placeReviewJpaRepository
-            .findAllByIdInOrderByCreatedAt(placeReviewIds)
-        val placeReviewImageEntities = placeReviewImageJpaRepository
-            .findAllByPlaceReviewIdIn(placeReviewEntities.map { it.id })
-
-        return placeReviewEntities.map { placeReviewEntity ->
-            placeReviewPersistenceMapper.toDomain(
-                placeReviewJpaEntity = placeReviewEntity,
-                placeReviewImageJpaEntities = placeReviewImageEntities
-                    .filter { it.placeReviewId == placeReviewEntity.id },
-            )
-        }
-    }
-
     override fun getAllByPlaceId(placeId: Long): List<PlaceReview> {
         val placeReviewEntities = placeReviewJpaRepository.findAllByPlaceIdOrderByCreatedAt(placeId)
         val placeReviewImageEntities = placeReviewImageJpaRepository


### PR DESCRIPTION
## 📝 개요
<!-- 이 PR의 목적과 관련된 정보를 간략히 설명합니다. -->
- 여러 가지 버그 수정(파라미터 순서, 누락된 이미지 로직)과 **OneLineReviews 타입 변경**, **평점 유효성 검증 로직 추가**, **사용하지 않는 메서드 삭제** 등의 리팩토링을을 하였습니다.

## ✨ 변경 사항
<!-- 코드나 기능의 주요 변경 사항을 설명 -->
1. **deletePlaceReview 파라미터 오류 수정**  
   - `DeletePlaceReviewUseCase.Command` 생성 시 파라미터 순서가 잘못 전달되던 문제를 해결했습니다.
2. **OneLineReviews 타입을 `List<String>`으로 변경**  
   -  단순 문자열 리스트로 관리하도록 수정하였습니다.
3. **누락된 이미지 엔티티 저장 로직 추가**  
   - 리뷰 생성 시 이미지 엔티티가 올바르게 저장되도록 처리했습니다.
4. **사용하지 않는 `getAllByPlaceReviewIds` 메서드 삭제**  
   - 필요하지 않은 PersistencePort 메서드를 제거했습니다.
5. **이벤트 객체를 팩토리 메서드로 반환하도록 리팩토링**  
   - `PlaceReviewCreateEvent`, `PlaceReviewUpdateEvent`, `PlaceReviewDeleteEvent` 팩토리 메서드를 통해 이벤트 객체를 생성하도록 변경했습니다.
6. **리뷰 평점 유효성 검증 로직 추가**  
   - `PlaceReview` 엔티티 생성 시 평점이 1.0 ~ 5.0 범위를 벗어나지 않도록 도메인 레벨에서 검증을 추가했습니다.
7. **User 리뷰 리스트 조회 시 장소 이름이 포함되도록 수정**  
   - `getAllMyPlaceReview` 응답이 장소 이름(`placeName`)을 함께 제공하도록 변경했습니다.
8. **Response DTO 구조 변경 (`PlaceReviewDetailsResponse` 삭제 후 2개 DTO로 분리)**  
   - `PlaceReviewWithWriterDetailsResponse`: 작성자 정보(`writer`)를 포함  
   - `PlaceReviewWithPlaceDetailsResponse`: 장소 정보(`placeName`)를 포함  
   - 각 상황(모든 리뷰 조회, 특정 사용자 리뷰 조회)에 맞는 DTO로 응답 형식을 분리했습니다.

## 🔗 관련 이슈
<!-- 이 PR과 관련된 이슈 번호를 연결 (없으면 생략) -->
- #179 

## ℹ️ 참고 사항
<!-- 리뷰어가 알 필요가 있는 추가 정보나 문서, 참고 링크를 포함 (없으면 생략) -->
-  API 테스트 완료
- 부족한 부분 있으면 피드백 부탁드리겠습니다. 감사합니다.
