### PR TITLE
fix: 과도한 플랜 공유 알림 생성으로 인한 스케줄링 주기 변경

### DIFF
--- a/core/src/main/kotlin/kr/wooco/woocobe/core/plan/application/scheduler/PlanScheduler.kt
+++ b/core/src/main/kotlin/kr/wooco/woocobe/core/plan/application/scheduler/PlanScheduler.kt
@@ -13,7 +13,7 @@ class PlanScheduler(
     private val eventPublisher: ApplicationEventPublisher,
 ) {
     @Transactional
-    @Scheduled(cron = "0 0 * * * ?")
+    @Scheduled(cron = "0 0 0 * * ?")
     fun checkUnsharedPlan() {
         loadPlanPersistencePort
             .getAllByIsSharedFalse()


### PR DESCRIPTION
## 📝 개요

- 플랜 공유 알림 생성을 위한 스케줄링 주기를 변경합니다.

## ✨ 변경 사항

- ✨ 플랜 공유 알림 생성을 위한 스케줄링 주기를 1시간에 한 번 -> 매일 자정으로 변경

## 🔗 관련 이슈

<!-- 이 PR과 관련된 이슈 번호를 연결 (없으면 생략) -->

- closed #181 

## ℹ️ 참고 사항

- 기존 1시간에 한 번씩 공유되지 않은 플랜에 대한 공유 요청 알림을 생성했으나, 아직 중복 알림에 대한 관리를 하지 않아 알림이 많이 생성되고 있습니다. 이에 급한대로 스케줄링 주기를 하루에 한 번(매일 자정)으로 변경하였습니다.
