### PR TITLE
build: flyway 의존성 추가 및 prod 배포 스크립트 추가

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -55,7 +55,7 @@ jobs:
           file: ./Dockerfile-api
           push: true
           platforms: linux/amd64
-          tags: ${{ secrets.DEV_DOCKER_HUB_REPOSITORY }}:${{ secrets.DEV_IMAGE_TAG }}
+          tags: ${{ secrets.DOCKER_HUB_REPOSITORY }}:${{ secrets.IMAGE_TAG }}
 
   docker-pull-and-run:
     runs-on: [ self-hosted, Linux, X64, dev ]
@@ -66,7 +66,7 @@ jobs:
       - name: 배포 이미지 가져오기
         run: |
           sudo docker login --username ${{ secrets.DOCKER_HUB_USERNAME }} --password ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
-          sudo docker pull ${{ secrets.DEV_DOCKER_HUB_REPOSITORY }}:${{ secrets.DEV_IMAGE_TAG }}
+          sudo docker pull ${{ secrets.DOCKER_HUB_REPOSITORY }}:${{ secrets.IMAGE_TAG }}
 
       - name: blue green 배포 스크립트 실행
         run: |

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,0 +1,78 @@
+name: Deploy PROD
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+jobs:
+  docker-build-and-push:
+    runs-on: ubuntu-latest
+    environment: prod
+
+    steps:
+      - name: 리포지토리 체크아웃
+        uses: actions/checkout@v3
+
+      - name: JDK 17 버전 설치
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: PROD 배포 환경변수 설정
+        run: |
+          echo "${{ secrets.SPRING_ENV }}" | base64 -d > bootstrap/api/src/main/resources/.env
+
+      - name: Gradle 캐싱
+        uses: actions/cache@v4
+        id: cache-gradle
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Gradle 을 통해 빌드
+        run: |
+          chmod +x ./gradlew
+          ./gradlew :bootstrap:api:bootJar
+
+      - name: Docker 빌드 도구 설정
+        uses: docker/setup-buildx-action@v2.9.1
+
+      - name: Docker Hub 로그인
+        uses: docker/login-action@v2.2.0
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+      - name: Docker 이미지 빌드 및 푸시
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: ./Dockerfile-api
+          push: true
+          platforms: linux/amd64
+          tags: ${{ secrets.DOCKER_HUB_REPOSITORY }}:${{ secrets.IMAGE_TAG }}
+
+  docker-pull-and-run:
+    runs-on: [ self-hosted, Linux, X64, prod ]
+    needs: docker-build-and-push
+    if: success()
+
+    steps:
+      - name: 배포 이미지 가져오기
+        run: |
+          sudo docker login --username ${{ secrets.DOCKER_HUB_USERNAME }} --password ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+          sudo docker pull ${{ secrets.DOCKER_HUB_REPOSITORY }}:${{ secrets.IMAGE_TAG }}
+
+      - name: blue green 배포 스크립트 실행
+        run: |
+          sudo chmod +x deploy.sh
+          sudo ./deploy.sh
+
+      - name: 사용하지 않는 도커 이미지 정리
+        run: |
+          sudo docker image prune --all --force

--- a/infrastructure/mysql/build.gradle.kts
+++ b/infrastructure/mysql/build.gradle.kts
@@ -13,6 +13,8 @@ dependencies {
     implementation(project(":support:common"))
 
     runtimeOnly("com.mysql:mysql-connector-j")
+    implementation("org.flywaydb:flyway-core")
+    implementation("org.flywaydb:flyway-mysql")
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("com.github.f4b6a3:tsid-creator:${property("tsidCreatorVersion")}")
     implementation("com.linecorp.kotlin-jdsl:jpql-dsl:${property("jdslVersion")}")

--- a/infrastructure/mysql/src/main/kotlin/kr/wooco/woocobe/mysql/plan/entity/PlanPlaceJpaEntity.kt
+++ b/infrastructure/mysql/src/main/kotlin/kr/wooco/woocobe/mysql/plan/entity/PlanPlaceJpaEntity.kt
@@ -17,5 +17,6 @@ class PlanPlaceJpaEntity(
     @Column(name = "place_id")
     val placeId: Long,
     @Id @Tsid
+    @Column(name = "plan_place_id")
     override val id: Long = 0L,
 ) : BaseTimeEntity()

--- a/infrastructure/mysql/src/main/resources/application-mysql.yml
+++ b/infrastructure/mysql/src/main/resources/application-mysql.yml
@@ -1,11 +1,21 @@
 spring:
   jpa:
     hibernate:
-      ddl-auto: ${HIBERNATE_DDL_AUTO:update}
+      ddl-auto: ${HIBERNATE_DDL_AUTO:validate}
     open-in-view: false
 
+  flyway:
+    enabled: true
+    locations: classpath:db/migration
+    baseline-on-migrate: ${FLYWAY_BASELINE_ON_MIGRATE:true}
+
   datasource:
-    url: ${MYSQL_URL:jdbc:mysql://localhost:3306/wooco-local-database?serverTimezone=Asia/Seoul&characterEncoding=UTF-8}
+    url: ${MYSQL_URL:jdbc:mysql://localhost:3306/wooco-local-database}
     username: ${MYSQL_USERNAME:wooco-local-user}
     password: ${MYSQL_PASSWORD:wooco-local-password}
     driver-class-name: com.mysql.cj.jdbc.Driver
+    hikari:
+      data-source-properties:
+        profileSQL: ${HIKARI_PROFILE_SQL:false}
+        serverTimezone: Asia/Seoul
+        characterEncoding: UTF-8

--- a/infrastructure/mysql/src/main/resources/db/migration/V1__init.sql
+++ b/infrastructure/mysql/src/main/resources/db/migration/V1__init.sql
@@ -1,0 +1,152 @@
+-- V1__init.sql
+
+CREATE TABLE auth_users (
+    auth_user_id BIGINT PRIMARY KEY,
+    social_type VARCHAR(255) NOT NULL,
+    social_id VARCHAR(255) NOT NULL,
+    user_id BIGINT NOT NULL
+);
+
+CREATE TABLE course_categories (
+    course_category_id BIGINT PRIMARY KEY,
+    category_name VARCHAR(255) NOT NULL,
+    course_id BIGINT NOT NULL
+);
+
+CREATE TABLE courses (
+    course_id BIGINT PRIMARY KEY,
+    comment_count BIGINT NOT NULL,
+    interest_count BIGINT NOT NULL,
+    view_count BIGINT NOT NULL,
+    visit_date DATE NOT NULL,
+    contents TEXT NOT NULL,
+    secondary_region VARCHAR(255) NOT NULL,
+    primary_region VARCHAR(255) NOT NULL,
+    title VARCHAR(255) NOT NULL,
+    user_id BIGINT NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+);
+
+CREATE TABLE course_places (
+    course_place_id BIGINT PRIMARY KEY,
+    course_place_order INT NOT NULL,
+    course_id BIGINT NOT NULL,
+    place_id BIGINT NOT NULL
+);
+
+CREATE TABLE interest_courses (
+    interest_course_id BIGINT PRIMARY KEY,
+    course_id BIGINT NOT NULL,
+    interest_user_id BIGINT NOT NULL
+);
+
+CREATE TABLE course_comments (
+    course_comment_id BIGINT PRIMARY KEY,
+    contents TEXT NOT NULL,
+    course_id BIGINT NOT NULL,
+    comment_user_id BIGINT NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+);
+
+CREATE TABLE device_tokens (
+    device_token_id BIGINT PRIMARY KEY,
+    token VARCHAR(255) NOT NULL UNIQUE,
+    user_id BIGINT NOT NULL,
+    is_active BOOLEAN NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+);
+
+CREATE TABLE notifications (
+    notification_id BIGINT PRIMARY KEY,
+    user_id BIGINT NOT NULL,
+    target_id BIGINT NOT NULL,
+    target_name VARCHAR(255) NOT NULL,
+    is_read BOOLEAN NOT NULL,
+    type VARCHAR(255) NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+);
+
+CREATE TABLE places (
+    place_id BIGINT PRIMARY KEY,
+    phone_number VARCHAR(255) NOT NULL,
+    thumbnail_url VARCHAR(255) NOT NULL,
+    review_count BIGINT NOT NULL,
+    average_rating DOUBLE NOT NULL,
+    kakao_map_place_id VARCHAR(255) NOT NULL,
+    longitude DOUBLE NOT NULL,
+    latitude DOUBLE NOT NULL,
+    address VARCHAR(255) NOT NULL,
+    name VARCHAR(255) NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+);
+
+CREATE TABLE place_one_line_reviews (
+    place_one_line_review_id BIGINT PRIMARY KEY,
+    contents VARCHAR(255) NOT NULL,
+    place_review_id BIGINT NOT NULL,
+    place_id BIGINT NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+);
+
+CREATE TABLE place_review_images (
+    place_review_images_id BIGINT PRIMARY KEY,
+    image_url VARCHAR(255) NOT NULL,
+    place_id BIGINT NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+);
+
+CREATE TABLE place_reviews (
+    place_review_id BIGINT PRIMARY KEY,
+    contents TEXT NOT NULL,
+    rating DOUBLE NOT NULL,
+    user_id BIGINT NOT NULL,
+    place_id BIGINT NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+);
+
+CREATE TABLE plans (
+    plan_id BIGINT PRIMARY KEY,
+    user_id BIGINT NOT NULL,
+    title VARCHAR(20) NOT NULL,
+    contents TEXT NOT NULL,
+    primary_region VARCHAR(255) NOT NULL,
+    secondary_region VARCHAR(255) NOT NULL,
+    is_shared BOOLEAN NOT NULL,
+    visit_date DATE NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+);
+
+CREATE TABLE plan_places (
+    plan_place_id BIGINT PRIMARY KEY,
+    plan_place_order INT NOT NULL,
+    plan_id BIGINT NOT NULL,
+    place_id BIGINT NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+);
+
+CREATE TABLE preference_regions (
+    region_id BIGINT PRIMARY KEY,
+    primary_region VARCHAR(255) NOT NULL,
+    secondary_region VARCHAR(255) NOT NULL,
+    user_id BIGINT NOT NULL
+);
+
+CREATE TABLE users (
+    user_id BIGINT PRIMARY KEY,
+    status VARCHAR(255) NOT NULL,
+    description VARCHAR(255) NOT NULL,
+    profile_url VARCHAR(255) NOT NULL,
+    name VARCHAR(255) NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+);

--- a/infrastructure/mysql/src/main/resources/db/migration/V1__init.sql
+++ b/infrastructure/mysql/src/main/resources/db/migration/V1__init.sql
@@ -4,7 +4,9 @@ CREATE TABLE auth_users (
     auth_user_id BIGINT PRIMARY KEY,
     social_type VARCHAR(255) NOT NULL,
     social_id VARCHAR(255) NOT NULL,
-    user_id BIGINT NOT NULL
+    user_id BIGINT NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
 );
 
 CREATE TABLE course_categories (


### PR DESCRIPTION
## 📝 개요

<!-- 이 PR의 목적과 관련된 정보를 간략히 설명합니다. -->

db 마이그레이션 툴 `flyway` 적용 및 `prod` 배포 스크립트 추가합니다

## ✨ 변경 사항

<!-- 코드나 기능의 주요 변경 사항을 설명 -->

- ✨ flyway 의존성 추가
- ✨ 초기 ddl 스크립트(`V1__init.sql` ) 추가
- ✨ prod 배포 스크립트 추가
- ✨ dev 배포 스크립트 환경변수 이름 수정

## 🔗 관련 이슈

<!-- 이 PR과 관련된 이슈 번호를 연결 (없으면 생략) -->

- closed #187 

## ℹ️ 참고 사항

<!-- 리뷰어가 알 필요가 있는 추가 정보나 문서, 참고 링크를 포함 (없으면 생략) -->

jpa의 `ddl-auto` 옵션 기본값을 `validate`로 수정했습니다

현재 오토스케일링을 고려하지 않은 상태라서 개별 인스턴스로의 배포만 가능한 상태입니다
만약, 서비스 사용자가 계속해서 증가하는 추세가 보인다면 ECS 로 마이그레이션 진행예정입니다.
