### PR TITLE
fix: 코스 상세 조회시 관심 여부 반환 버그 수정

### DIFF
--- a/core/src/main/kotlin/kr/wooco/woocobe/core/course/application/service/CourseQueryService.kt
+++ b/core/src/main/kotlin/kr/wooco/woocobe/core/course/application/service/CourseQueryService.kt
@@ -30,7 +30,7 @@ internal class CourseQueryService(
         val placeIds = course.coursePlaces.map { it.placeId }.distinct()
         val places = loadPlacePersistencePort.getAllByPlaceIds(placeIds)
         val isInterest = query.userId?.run {
-            loadInterestCoursePersistencePort.existsByUserIdAndCourseId(course.id, query.userId)
+            loadInterestCoursePersistencePort.existsByUserIdAndCourseId(query.userId, course.id)
         } ?: false
         return CourseResult.of(course, user, places, isInterest)
     }


### PR DESCRIPTION
## 📝 개요

<!-- 이 PR의 목적과 관련된 정보를 간략히 설명합니다. -->

코스 상세 조회시 관심 여부가 정상적으로 반환되지 않는 버그 수정

## ✨ 변경 사항

<!-- 코드나 기능의 주요 변경 사항을 설명 -->

- ✨ `userId`와 `courseId`가 식별자값이 반대로 되어있었던 버그 수정

## 🔗 관련 이슈

<!-- 이 PR과 관련된 이슈 번호를 연결 (없으면 생략) -->

- closed #191 

## ℹ️ 참고 사항

<!-- 리뷰어가 알 필요가 있는 추가 정보나 문서, 참고 링크를 포함 (없으면 생략) -->

- 
