### PR TITLE
refactor: 플랜 도메인 포트 및 어댑터 등 컨벤션 통일

### DIFF
--- a/core/src/main/kotlin/kr/wooco/woocobe/core/plan/application/port/out/DeletePlanPersistencePort.kt
+++ b/core/src/main/kotlin/kr/wooco/woocobe/core/plan/application/port/out/DeletePlanPersistencePort.kt
@@ -1,5 +1,0 @@
-package kr.wooco.woocobe.core.plan.application.port.out
-
-interface DeletePlanPersistencePort {
-    fun deleteByPlanId(planId: Long)
-}

--- a/core/src/main/kotlin/kr/wooco/woocobe/core/plan/application/port/out/PlanCommandPort.kt
+++ b/core/src/main/kotlin/kr/wooco/woocobe/core/plan/application/port/out/PlanCommandPort.kt
@@ -2,6 +2,8 @@ package kr.wooco.woocobe.core.plan.application.port.out
 
 import kr.wooco.woocobe.core.plan.domain.entity.Plan
 
-interface SavePlanPersistencePort {
+interface PlanCommandPort {
     fun savePlan(plan: Plan): Plan
+
+    fun deleteByPlanId(planId: Long)
 }

--- a/core/src/main/kotlin/kr/wooco/woocobe/core/plan/application/port/out/PlanQueryPort.kt
+++ b/core/src/main/kotlin/kr/wooco/woocobe/core/plan/application/port/out/PlanQueryPort.kt
@@ -3,7 +3,7 @@ package kr.wooco.woocobe.core.plan.application.port.out
 import kr.wooco.woocobe.core.plan.domain.entity.Plan
 import java.time.LocalDateTime
 
-interface LoadPlanPersistencePort {
+interface PlanQueryPort {
     fun getByPlanId(planId: Long): Plan
 
     fun getAllByUserId(userId: Long): List<Plan>

--- a/core/src/main/kotlin/kr/wooco/woocobe/core/plan/application/scheduler/PlanScheduler.kt
+++ b/core/src/main/kotlin/kr/wooco/woocobe/core/plan/application/scheduler/PlanScheduler.kt
@@ -1,6 +1,6 @@
 package kr.wooco.woocobe.core.plan.application.scheduler
 
-import kr.wooco.woocobe.core.plan.application.port.out.LoadPlanPersistencePort
+import kr.wooco.woocobe.core.plan.application.port.out.PlanQueryPort
 import kr.wooco.woocobe.core.plan.domain.event.PlanShareRequestEvent
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.scheduling.annotation.Scheduled
@@ -9,14 +9,14 @@ import java.time.LocalDate
 
 @Component
 class PlanScheduler(
-    private val loadPlanPersistencePort: LoadPlanPersistencePort,
+    private val planQueryPort: PlanQueryPort,
     private val eventPublisher: ApplicationEventPublisher,
 ) {
     @Scheduled(cron = "0 0 0 * * ?")
-    fun checkUnsharedPlan() {
+    fun publishEventsForYesterdayPlans() {
         val yesterdayStart = LocalDate.now().minusDays(1).atStartOfDay()
         val yesterdayEnd = LocalDate.now().atStartOfDay()
-        val plans = loadPlanPersistencePort.getAllByCreatedAtBetween(
+        val plans = planQueryPort.getAllByCreatedAtBetween(
             startDate = yesterdayStart,
             endDate = yesterdayEnd,
         )

--- a/core/src/main/kotlin/kr/wooco/woocobe/core/plan/application/service/PlanQueryService.kt
+++ b/core/src/main/kotlin/kr/wooco/woocobe/core/plan/application/service/PlanQueryService.kt
@@ -4,19 +4,19 @@ import kr.wooco.woocobe.core.place.application.port.out.PlaceQueryPort
 import kr.wooco.woocobe.core.plan.application.port.`in`.ReadAllPlanUseCase
 import kr.wooco.woocobe.core.plan.application.port.`in`.ReadPlanUseCase
 import kr.wooco.woocobe.core.plan.application.port.`in`.results.PlanResult
-import kr.wooco.woocobe.core.plan.application.port.out.LoadPlanPersistencePort
+import kr.wooco.woocobe.core.plan.application.port.out.PlanQueryPort
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
 @Service
 internal class PlanQueryService(
-    private val loadPlanPersistencePort: LoadPlanPersistencePort,
+    private val planQueryPort: PlanQueryPort,
     private val placeQueryPort: PlaceQueryPort,
 ) : ReadPlanUseCase,
     ReadAllPlanUseCase {
     @Transactional(readOnly = true)
     override fun readPlan(query: ReadPlanUseCase.Query): PlanResult {
-        val plan = loadPlanPersistencePort.getByPlanId(query.planId)
+        val plan = planQueryPort.getByPlanId(query.planId)
         val placeIds = plan.places.map { it.placeId }
         val places = placeQueryPort.getAllByPlaceIds(placeIds)
         return PlanResult.of(plan, places)
@@ -24,7 +24,7 @@ internal class PlanQueryService(
 
     @Transactional(readOnly = true)
     override fun readAllPlan(query: ReadAllPlanUseCase.Query): List<PlanResult> {
-        val plans = loadPlanPersistencePort.getAllByUserId(query.userId)
+        val plans = planQueryPort.getAllByUserId(query.userId)
         val placeIds = plans.flatMap { it.places }.map { it.placeId }
         val places = placeQueryPort.getAllByPlaceIds(placeIds)
         return PlanResult.listOf(plans, places)

--- a/core/src/main/kotlin/kr/wooco/woocobe/core/plan/domain/entity/Plan.kt
+++ b/core/src/main/kotlin/kr/wooco/woocobe/core/plan/domain/entity/Plan.kt
@@ -8,11 +8,11 @@ import java.time.LocalDate
 data class Plan(
     val id: Long,
     val userId: Long,
-    var title: String,
-    var contents: String,
-    var region: PlanRegion,
-    var visitDate: LocalDate,
-    var places: List<PlanPlace>,
+    val title: String,
+    val contents: String,
+    val region: PlanRegion,
+    val visitDate: LocalDate,
+    val places: List<PlanPlace>,
 ) {
     fun update(
         userId: Long,
@@ -21,14 +21,15 @@ data class Plan(
         region: PlanRegion,
         visitDate: LocalDate,
         placeIds: List<Long>,
-    ) {
+    ): Plan {
         validateWriter(userId)
-
-        this.title = title
-        this.contents = contents
-        this.region = region
-        this.visitDate = visitDate
-        this.places = processPlanPlaceOrder(placeIds)
+        return copy(
+            title = title,
+            contents = contents,
+            region = region,
+            visitDate = visitDate,
+            places = processPlanPlaceOrder(placeIds),
+        )
     }
 
     fun validateWriter(userId: Long) {

--- a/infrastructure/mysql/src/main/kotlin/kr/wooco/woocobe/mysql/plan/PlanPersistenceMapper.kt
+++ b/infrastructure/mysql/src/main/kotlin/kr/wooco/woocobe/mysql/plan/PlanPersistenceMapper.kt
@@ -5,11 +5,9 @@ import kr.wooco.woocobe.core.plan.domain.vo.PlanPlace
 import kr.wooco.woocobe.core.plan.domain.vo.PlanRegion
 import kr.wooco.woocobe.mysql.plan.entity.PlanJpaEntity
 import kr.wooco.woocobe.mysql.plan.entity.PlanPlaceJpaEntity
-import org.springframework.stereotype.Component
 
-@Component
-internal class PlanPersistenceMapper {
-    fun toDomain(
+internal object PlanPersistenceMapper {
+    fun toDomainEntity(
         planJpaEntity: PlanJpaEntity,
         planPlaceJpaEntities: List<PlanPlaceJpaEntity>,
     ): Plan =
@@ -26,7 +24,7 @@ internal class PlanPersistenceMapper {
             places = planPlaceJpaEntities.map { PlanPlace(order = it.order, placeId = it.placeId) },
         )
 
-    fun toEntity(plan: Plan): PlanJpaEntity =
+    fun toJpaEntity(plan: Plan): PlanJpaEntity =
         PlanJpaEntity(
             id = plan.id,
             userId = plan.userId,

--- a/infrastructure/mysql/src/main/kotlin/kr/wooco/woocobe/mysql/plan/PlanPlacePersistenceMapper.kt
+++ b/infrastructure/mysql/src/main/kotlin/kr/wooco/woocobe/mysql/plan/PlanPlacePersistenceMapper.kt
@@ -1,25 +1,16 @@
 package kr.wooco.woocobe.mysql.plan
 
 import kr.wooco.woocobe.core.plan.domain.vo.PlanPlace
-import kr.wooco.woocobe.mysql.plan.entity.PlanJpaEntity
 import kr.wooco.woocobe.mysql.plan.entity.PlanPlaceJpaEntity
-import org.springframework.stereotype.Component
 
-@Component
-internal class PlanPlacePersistenceMapper {
-    fun toDomain(planPlaceJpaEntity: PlanPlaceJpaEntity): PlanPlace =
-        PlanPlace(
-            order = planPlaceJpaEntity.order,
-            placeId = planPlaceJpaEntity.placeId,
-        )
-
-    fun toEntity(
-        planJpaEntity: PlanJpaEntity,
+internal object PlanPlacePersistenceMapper {
+    fun toJpaEntity(
+        planId: Long,
         planPlace: PlanPlace,
     ): PlanPlaceJpaEntity =
         PlanPlaceJpaEntity(
             order = planPlace.order,
-            planId = planJpaEntity.id,
+            planId = planId,
             placeId = planPlace.placeId,
         )
 }


### PR DESCRIPTION
## 📝 개요

- 플랜 도메인 out 포트 네이밍 및 어댑터 컨벤션을 통일합니다.
- 플랜 도메인 클래스 내 필드를 불변으로 변경합니다.

## ✨ 변경 사항

- ✨ Out port 를 `PlanCommandPort`, `PlanQueryPort` 로 통합
- ✨ 매퍼 클래스 `object`로 변경
- ✨ 플랜 도메인 클래스 내 필드 불변으로 변경

## 🔗 관련 이슈

- closed #200
