### PR TITLE
fix: PreAuthorize 버그 해결 및 엑츄에이터 포트 수정

### DIFF
--- a/bootstrap/api/src/main/kotlin/kr/wooco/woocobe/api/auth/AuthController.kt
+++ b/bootstrap/api/src/main/kotlin/kr/wooco/woocobe/api/auth/AuthController.kt
@@ -2,7 +2,6 @@ package kr.wooco.woocobe.api.auth
 
 import jakarta.servlet.http.HttpServletResponse
 import kr.wooco.woocobe.api.auth.response.TokenResponse
-import kr.wooco.woocobe.api.common.security.LoginRequired
 import kr.wooco.woocobe.api.common.utils.JwtUtils
 import kr.wooco.woocobe.api.common.utils.addCookie
 import kr.wooco.woocobe.api.common.utils.deleteCookie
@@ -38,7 +37,6 @@ class AuthController(
         return ResponseEntity.ok(TokenResponse(accessToken))
     }
 
-    @LoginRequired
     @PostMapping("/logout")
     override fun logout(
         @CookieValue(REFRESH_TOKEN_COOKIE_NAME, required = false) refreshToken: String?,

--- a/bootstrap/api/src/main/kotlin/kr/wooco/woocobe/api/common/config/WebSecurityConfig.kt
+++ b/bootstrap/api/src/main/kotlin/kr/wooco/woocobe/api/common/config/WebSecurityConfig.kt
@@ -5,6 +5,7 @@ import kr.wooco.woocobe.api.common.security.CustomOAuth2UserService
 import kr.wooco.woocobe.api.common.security.JwtAuthenticationFilter
 import kr.wooco.woocobe.api.common.security.OAuthFailureHandler
 import kr.wooco.woocobe.api.common.security.OAuthSuccessHandler
+import kr.wooco.woocobe.api.common.security.SecurityIgnorePath
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity
@@ -36,11 +37,16 @@ class WebSecurityConfig(
             .anonymous { it.disable() }
             .exceptionHandling { it.disable() }
             .sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }
-            .authorizeHttpRequests { it.anyRequest().permitAll() }
             .addFilterBefore(
                 JwtAuthenticationFilter(),
                 UsernamePasswordAuthenticationFilter::class.java,
-            ).oauth2Login {
+            ).authorizeHttpRequests {
+                it
+                    .requestMatchers(SecurityIgnorePath.ignoreRequestMatcher)
+                    .permitAll()
+                    .anyRequest()
+                    .authenticated()
+            }.oauth2Login {
                 it
                     .authorizationEndpoint { config ->
                         config.baseUri(AUTHORIZATION_REQUEST_URI)

--- a/bootstrap/api/src/main/kotlin/kr/wooco/woocobe/api/common/security/SecurityIgnorePath.kt
+++ b/bootstrap/api/src/main/kotlin/kr/wooco/woocobe/api/common/security/SecurityIgnorePath.kt
@@ -10,7 +10,7 @@ object SecurityIgnorePath {
     private fun initIgnorePaths(): OrRequestMatcher =
         OrRequestMatcher(
             append(path = "/api-docs/**", method = HttpMethod.GET),
-            append(path = "/actuator/health", method = HttpMethod.GET),
+            append(path = "/actuator/**", method = HttpMethod.GET),
             append(path = "/swagger-ui/**", method = HttpMethod.GET),
             // course
             append(path = "/api/v1/courses", method = HttpMethod.GET),

--- a/bootstrap/api/src/main/kotlin/kr/wooco/woocobe/api/common/security/SecurityIgnorePath.kt
+++ b/bootstrap/api/src/main/kotlin/kr/wooco/woocobe/api/common/security/SecurityIgnorePath.kt
@@ -1,0 +1,38 @@
+package kr.wooco.woocobe.api.common.security
+
+import org.springframework.http.HttpMethod
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher
+import org.springframework.security.web.util.matcher.OrRequestMatcher
+
+object SecurityIgnorePath {
+    val ignoreRequestMatcher: OrRequestMatcher = initIgnorePaths()
+
+    private fun initIgnorePaths(): OrRequestMatcher =
+        OrRequestMatcher(
+            append(path = "/api-docs/**", method = HttpMethod.GET),
+            append(path = "/actuator/health", method = HttpMethod.GET),
+            append(path = "/swagger-ui/**", method = HttpMethod.GET),
+            // course
+            append(path = "/api/v1/courses", method = HttpMethod.GET),
+            append(path = "/api/v1/courses/{courseId:[0-9]+}", method = HttpMethod.GET),
+            append(path = "/api/v1/courses/users/{userId:[0-9]+}", method = HttpMethod.GET),
+            append(path = "/api/v1/courses/users/{userId:[0-9]+}/like", method = HttpMethod.GET),
+            append(path = "/api/v1/comments/courses/{courseId:[0-9]+}", method = HttpMethod.GET),
+            // place
+            append(path = "/api/v1/places/{placeId[0-9]+}", method = HttpMethod.GET),
+            append(path = "/api/v1/reviews/{placeReviewId:[0-9]+}", method = HttpMethod.GET),
+            append(path = "/api/v1/reviews/places/{placeId:[0-9]+}", method = HttpMethod.GET),
+            append(path = "/api/v1/reviews/places/users/{userId:[0-9]+}", method = HttpMethod.GET),
+            // auth
+            append(path = "/api/v1/auth/reissue", method = HttpMethod.POST),
+            append(path = "/api/v1/auth/{provider}/social-login", method = HttpMethod.POST),
+            append(path = "/api/v1/auth/{provider}/social-login/url", method = HttpMethod.GET),
+            // user
+            append(path = "/api/v1/users/{userId:[0-9]+}", method = HttpMethod.GET),
+        )
+
+    private fun append(
+        path: String,
+        method: HttpMethod,
+    ): AntPathRequestMatcher = AntPathRequestMatcher(path, method.name())
+}

--- a/bootstrap/api/src/main/kotlin/kr/wooco/woocobe/api/course/CourseController.kt
+++ b/bootstrap/api/src/main/kotlin/kr/wooco/woocobe/api/course/CourseController.kt
@@ -1,6 +1,5 @@
 package kr.wooco.woocobe.api.course
 
-import kr.wooco.woocobe.api.common.security.LoginRequired
 import kr.wooco.woocobe.api.course.request.CreateCourseRequest
 import kr.wooco.woocobe.api.course.request.UpdateCourseRequest
 import kr.wooco.woocobe.api.course.response.CourseDetailResponse
@@ -107,7 +106,6 @@ class CourseController(
         return ResponseEntity.ok(CourseDetailResponse.listFrom(results))
     }
 
-    @LoginRequired
     @PostMapping
     override fun createCourse(
         @AuthenticationPrincipal userId: Long,
@@ -118,7 +116,6 @@ class CourseController(
         return ResponseEntity.status(HttpStatus.CREATED).body(CreateCourseResponse(results))
     }
 
-    @LoginRequired
     @PostMapping("/{courseId}/like")
     override fun addCourseLike(
         @AuthenticationPrincipal userId: Long,
@@ -129,7 +126,6 @@ class CourseController(
         return ResponseEntity.ok().build()
     }
 
-    @LoginRequired
     @PatchMapping("/{courseId}")
     override fun updateCourse(
         @AuthenticationPrincipal userId: Long,
@@ -141,7 +137,6 @@ class CourseController(
         return ResponseEntity.ok().build()
     }
 
-    @LoginRequired
     @DeleteMapping("/{courseId}")
     override fun deleteCourse(
         @AuthenticationPrincipal userId: Long,
@@ -152,7 +147,6 @@ class CourseController(
         return ResponseEntity.ok().build()
     }
 
-    @LoginRequired
     @DeleteMapping("/{courseId}/like")
     override fun deleteCourseLike(
         @AuthenticationPrincipal userId: Long,

--- a/bootstrap/api/src/main/kotlin/kr/wooco/woocobe/api/coursecomment/CourseCommentController.kt
+++ b/bootstrap/api/src/main/kotlin/kr/wooco/woocobe/api/coursecomment/CourseCommentController.kt
@@ -1,6 +1,5 @@
 package kr.wooco.woocobe.api.coursecomment
 
-import kr.wooco.woocobe.api.common.security.LoginRequired
 import kr.wooco.woocobe.api.coursecomment.request.CreateCourseCommentRequest
 import kr.wooco.woocobe.api.coursecomment.request.UpdateCourseCommentRequest
 import kr.wooco.woocobe.api.coursecomment.response.CourseCommentDetailResponse
@@ -38,7 +37,6 @@ class CourseCommentController(
         return ResponseEntity.ok(CourseCommentDetailResponse.listFrom(results))
     }
 
-    @LoginRequired
     @PostMapping("/courses/{courseId}")
     override fun createCourseComment(
         @AuthenticationPrincipal userId: Long,
@@ -50,7 +48,6 @@ class CourseCommentController(
         return ResponseEntity.status(HttpStatus.CREATED).body(CreateCourseCommentResponse(results))
     }
 
-    @LoginRequired
     @PatchMapping("/{commentId}")
     override fun updateCourseComment(
         @AuthenticationPrincipal userId: Long,
@@ -62,7 +59,6 @@ class CourseCommentController(
         return ResponseEntity.ok().build()
     }
 
-    @LoginRequired
     @DeleteMapping("/{commentId}")
     override fun deleteCourseComment(
         @AuthenticationPrincipal userId: Long,

--- a/bootstrap/api/src/main/kotlin/kr/wooco/woocobe/api/image/ImageController.kt
+++ b/bootstrap/api/src/main/kotlin/kr/wooco/woocobe/api/image/ImageController.kt
@@ -1,6 +1,5 @@
 package kr.wooco.woocobe.api.image
 
-import kr.wooco.woocobe.api.common.security.LoginRequired
 import kr.wooco.woocobe.api.image.response.ImageUploadUrlResponse
 import kr.wooco.woocobe.core.image.application.port.`in`.ReadUploadImageUrlUseCase
 import org.springframework.http.ResponseEntity
@@ -13,7 +12,6 @@ import org.springframework.web.bind.annotation.RestController
 class ImageController(
     private val readUploadImageUrlUseCase: ReadUploadImageUrlUseCase,
 ) : ImageApi {
-    @LoginRequired
     @GetMapping("/upload/url")
     override fun getUploadUrl(): ResponseEntity<ImageUploadUrlResponse> {
         val results = readUploadImageUrlUseCase.readUploadImageUrl()

--- a/bootstrap/api/src/main/kotlin/kr/wooco/woocobe/api/notification/NotificationController.kt
+++ b/bootstrap/api/src/main/kotlin/kr/wooco/woocobe/api/notification/NotificationController.kt
@@ -1,6 +1,5 @@
 package kr.wooco.woocobe.api.notification
 
-import kr.wooco.woocobe.api.common.security.LoginRequired
 import kr.wooco.woocobe.api.notification.request.CreateDeviceTokenRequest
 import kr.wooco.woocobe.api.notification.response.NotificationDetailResponse
 import kr.wooco.woocobe.core.notification.application.port.`in`.CreateDeviceTokenUseCase
@@ -26,7 +25,6 @@ class NotificationController(
     private val createDeviceTokenUseCase: CreateDeviceTokenUseCase,
     private val deleteDeviceTokenUseCase: DeleteDeviceTokenUseCase,
 ) : NotificationApi {
-    @LoginRequired
     @GetMapping
     override fun getAllUserNotification(
         @AuthenticationPrincipal userId: Long,
@@ -36,7 +34,6 @@ class NotificationController(
         return ResponseEntity.ok(NotificationDetailResponse.listFrom(results))
     }
 
-    @LoginRequired
     @PatchMapping("/{notificationId}")
     override fun markAsReadNotification(
         @AuthenticationPrincipal userId: Long,
@@ -49,7 +46,6 @@ class NotificationController(
         markAsReadNotificationUseCase.markAsReadNotification(command)
     }
 
-    @LoginRequired
     @PostMapping
     override fun createDeviceToken(
         @AuthenticationPrincipal userId: Long,
@@ -62,7 +58,6 @@ class NotificationController(
         createDeviceTokenUseCase.createDeviceToken(command)
     }
 
-    @LoginRequired
     @DeleteMapping("/{token}")
     override fun deleteDeviceToken(
         @AuthenticationPrincipal userId: Long,

--- a/bootstrap/api/src/main/kotlin/kr/wooco/woocobe/api/place/PlaceController.kt
+++ b/bootstrap/api/src/main/kotlin/kr/wooco/woocobe/api/place/PlaceController.kt
@@ -1,6 +1,5 @@
 package kr.wooco.woocobe.api.place
 
-import kr.wooco.woocobe.api.common.security.LoginRequired
 import kr.wooco.woocobe.api.place.request.CreatePlaceRequest
 import kr.wooco.woocobe.api.place.response.CreatePlaceResponse
 import kr.wooco.woocobe.api.place.response.PlaceDetailResponse
@@ -31,7 +30,6 @@ class PlaceController(
         return ResponseEntity.ok(PlaceDetailResponse.from(results))
     }
 
-    @LoginRequired
     @PostMapping
     override fun createPlace(
         @AuthenticationPrincipal userId: Long,

--- a/bootstrap/api/src/main/kotlin/kr/wooco/woocobe/api/placereview/PlaceReviewController.kt
+++ b/bootstrap/api/src/main/kotlin/kr/wooco/woocobe/api/placereview/PlaceReviewController.kt
@@ -1,6 +1,5 @@
 package kr.wooco.woocobe.api.placereview
 
-import kr.wooco.woocobe.api.common.security.LoginRequired
 import kr.wooco.woocobe.api.placereview.request.CreatePlaceReviewRequest
 import kr.wooco.woocobe.api.placereview.request.UpdatePlaceReviewRequest
 import kr.wooco.woocobe.api.placereview.response.CreatePlaceReviewResponse
@@ -64,7 +63,6 @@ class PlaceReviewController(
         return ResponseEntity.ok(PlaceReviewWithPlaceDetailsResponse.listFrom(results))
     }
 
-    @LoginRequired
     @PostMapping("/places/{placeId}")
     override fun createPlaceReview(
         @AuthenticationPrincipal userId: Long,
@@ -76,7 +74,6 @@ class PlaceReviewController(
         return ResponseEntity.status(HttpStatus.CREATED).body(CreatePlaceReviewResponse(results))
     }
 
-    @LoginRequired
     @PatchMapping("/{placeReviewId}")
     override fun updatePlaceReview(
         @AuthenticationPrincipal userId: Long,
@@ -88,7 +85,6 @@ class PlaceReviewController(
         return ResponseEntity.ok().build()
     }
 
-    @LoginRequired
     @DeleteMapping("/{placeReviewId}")
     override fun deletePlaceReview(
         @AuthenticationPrincipal userId: Long,
@@ -99,7 +95,6 @@ class PlaceReviewController(
         return ResponseEntity.ok().build()
     }
 
-    @LoginRequired
     @GetMapping("/places/{placeId}/existence")
     override fun existsByPlaceReviewWriter(
         @PathVariable placeId: Long,

--- a/bootstrap/api/src/main/kotlin/kr/wooco/woocobe/api/plan/PlanController.kt
+++ b/bootstrap/api/src/main/kotlin/kr/wooco/woocobe/api/plan/PlanController.kt
@@ -1,6 +1,5 @@
 package kr.wooco.woocobe.api.plan
 
-import kr.wooco.woocobe.api.common.security.LoginRequired
 import kr.wooco.woocobe.api.plan.request.CreatePlanRequest
 import kr.wooco.woocobe.api.plan.request.UpdatePlanRequest
 import kr.wooco.woocobe.api.plan.response.CreatePlanResponse
@@ -30,7 +29,6 @@ class PlanController(
     private val readPlanUseCase: ReadPlanUseCase,
     private val readAllPlanUseCase: ReadAllPlanUseCase,
 ) : PlanApi {
-    @LoginRequired
     @PostMapping
     override fun createPlan(
         @AuthenticationPrincipal userId: Long,
@@ -41,7 +39,6 @@ class PlanController(
         return ResponseEntity.ok(CreatePlanResponse(response))
     }
 
-    @LoginRequired
     @GetMapping
     override fun getAllPlanDetail(
         @AuthenticationPrincipal userId: Long,
@@ -51,7 +48,6 @@ class PlanController(
         return ResponseEntity.ok(PlanDetailResponse.listOf(response))
     }
 
-    @LoginRequired
     @GetMapping("/{planId}")
     override fun getPlanDetail(
         @AuthenticationPrincipal userId: Long,
@@ -62,7 +58,6 @@ class PlanController(
         return ResponseEntity.ok(PlanDetailResponse.from(response))
     }
 
-    @LoginRequired
     @PatchMapping("/{planId}")
     override fun updatePlan(
         @AuthenticationPrincipal userId: Long,
@@ -74,7 +69,6 @@ class PlanController(
         return ResponseEntity.ok().build()
     }
 
-    @LoginRequired
     @DeleteMapping("/{planId}")
     override fun deletePlan(
         @AuthenticationPrincipal userId: Long,

--- a/bootstrap/api/src/main/kotlin/kr/wooco/woocobe/api/region/RegionController.kt
+++ b/bootstrap/api/src/main/kotlin/kr/wooco/woocobe/api/region/RegionController.kt
@@ -1,6 +1,5 @@
 package kr.wooco.woocobe.api.region
 
-import kr.wooco.woocobe.api.common.security.LoginRequired
 import kr.wooco.woocobe.api.region.request.CreatePreferenceRegionRequest
 import kr.wooco.woocobe.api.region.response.CreatePreferenceRegionResponse
 import kr.wooco.woocobe.api.region.response.PreferenceDetailResponse
@@ -30,7 +29,6 @@ class RegionController(
     private val addPreferenceRegionUseCase: AddPreferenceRegionUseCase,
     private val deletePreferenceRegionUseCase: DeletePreferenceRegionUseCase,
 ) : RegionApi {
-    @LoginRequired
     @PostMapping("/preferences")
     override fun addPreferenceRegion(
         @AuthenticationPrincipal userId: Long,
@@ -42,7 +40,6 @@ class RegionController(
         return ResponseEntity.ok(response)
     }
 
-    @LoginRequired
     @GetMapping("/preferences/check")
     override fun checkPreferenceRegion(
         @AuthenticationPrincipal userId: Long,
@@ -58,7 +55,6 @@ class RegionController(
         return ResponseEntity.ok(PreferenceDetailResponse.from(results))
     }
 
-    @LoginRequired
     @GetMapping("/preferences")
     override fun getAllMyPreferenceRegion(
         @AuthenticationPrincipal userId: Long,
@@ -69,7 +65,6 @@ class RegionController(
         return ResponseEntity.ok(response)
     }
 
-    @LoginRequired
     @DeleteMapping("/preferences/{preferenceRegionId}")
     override fun deletePreferenceRegion(
         @AuthenticationPrincipal userId: Long,

--- a/bootstrap/api/src/main/kotlin/kr/wooco/woocobe/api/user/UserController.kt
+++ b/bootstrap/api/src/main/kotlin/kr/wooco/woocobe/api/user/UserController.kt
@@ -1,6 +1,5 @@
 package kr.wooco.woocobe.api.user
 
-import kr.wooco.woocobe.api.common.security.LoginRequired
 import kr.wooco.woocobe.api.user.request.UpdateUserRequest
 import kr.wooco.woocobe.api.user.response.UserDetailResponse
 import kr.wooco.woocobe.core.user.application.port.`in`.ReadUserUseCase
@@ -24,7 +23,6 @@ class UserController(
     private val withdrawUserUseCase: WithdrawUserUseCase,
     private val updateUserProfileUseCase: UpdateUserProfileUseCase,
 ) : UserApi {
-    @LoginRequired
     @GetMapping("/me")
     override fun getCurrentUser(
         @AuthenticationPrincipal userId: Long,
@@ -43,7 +41,6 @@ class UserController(
         return ResponseEntity.ok(UserDetailResponse.from(results))
     }
 
-    @LoginRequired
     @PatchMapping("/profile")
     override fun updateProfile(
         @AuthenticationPrincipal userId: Long,
@@ -54,7 +51,6 @@ class UserController(
         return ResponseEntity.ok().build()
     }
 
-    @LoginRequired
     @DeleteMapping("/withdraw")
     override fun withdrawUser(
         @CookieValue(SOCIAL_TOKEN) socialToken: String,

--- a/infrastructure/rest/src/main/resources/application-rest.yml
+++ b/infrastructure/rest/src/main/resources/application-rest.yml
@@ -1,11 +1,4 @@
 app:
-  social:
-    kakao:
-      client-id: ${KAKAO_CLIENT_ID}
-      secret-key: ${KAKAO_SECRET_KEY}
-      grant-type: ${KAKAO_GRANT_TYPE:authorization_code}
-      redirect-uri: ${KAKAO_REDIRECT_URI}
-
   google:
     place:
       api-key: ${GOOGLE_PLACE_API_KEY}

--- a/support/metric/src/main/resources/application-metric.yml
+++ b/support/metric/src/main/resources/application-metric.yml
@@ -1,5 +1,6 @@
 management:
+  server.port: 9000
   endpoints:
     web:
       exposure:
-        include: "health"
+        include: ${ACTUATOR_INCLUDE:health,prometheus}


### PR DESCRIPTION
## 📝 개요

<!-- 이 PR의 목적과 관련된 정보를 간략히 설명합니다. -->

DEV 서버에서 발생하고 있는 500에러 해결 및 엑츄에이터 리스너 포트 번호를 수정합니다.

## ✨ 변경 사항

<!-- 코드나 기능의 주요 변경 사항을 설명 -->

- ✨ `@PreAuthorize` 제거
- ✨ 엑츄에이터 리스닝 포트 수정 (`8080` -> `9000`)

## 🔗 관련 이슈

<!-- 이 PR과 관련된 이슈 번호를 연결 (없으면 생략) -->

- closed #205 

## ℹ️ 참고 사항

<!-- 리뷰어가 알 필요가 있는 추가 정보나 문서, 참고 링크를 포함 (없으면 생략) -->

- #204 에서 추가 작업했던 `@PreAuthorize` 를 통한 인증 엔드포인트 관리 로직을 롤백했습니다.
