### PR TITLE
refactor: 알림, 플랜 도메인 soft delete 적용 및 네이밍 변경

### DIFF
--- a/core/src/main/kotlin/kr/wooco/woocobe/core/notification/application/port/out/DeviceTokenCommandPort.kt
+++ b/core/src/main/kotlin/kr/wooco/woocobe/core/notification/application/port/out/DeviceTokenCommandPort.kt
@@ -1,10 +1,7 @@
 package kr.wooco.woocobe.core.notification.application.port.out
 
 import kr.wooco.woocobe.core.notification.domain.entity.DeviceToken
-import kr.wooco.woocobe.core.notification.domain.vo.Token
 
 interface DeviceTokenCommandPort {
     fun saveDeviceToken(deviceToken: DeviceToken): DeviceToken
-
-    fun deleteByToken(token: Token)
 }

--- a/core/src/main/kotlin/kr/wooco/woocobe/core/notification/application/service/NotificationCommandService.kt
+++ b/core/src/main/kotlin/kr/wooco/woocobe/core/notification/application/service/NotificationCommandService.kt
@@ -31,7 +31,7 @@ class NotificationCommandService(
             userId = command.userId,
             targetId = command.targetId,
             targetName = command.targetName,
-            type = NotificationType.invoke(command.type),
+            type = NotificationType(command.type),
         )
         return notificationCommandPort.saveNotification(notification).id
     }
@@ -39,9 +39,7 @@ class NotificationCommandService(
     @Transactional
     override fun markAsReadNotification(command: MarkAsReadNotificationUseCase.Command) {
         val notification = notificationQueryPort.getByNotificationId(command.notificationId)
-        notification.validateOwner(command.userId)
-
-        val readNotification = notification.markAsRead()
+        val readNotification = notification.markAsRead(command.userId)
         notificationCommandPort.saveNotification(readNotification)
     }
 
@@ -59,7 +57,7 @@ class NotificationCommandService(
     override fun deleteDeviceToken(command: DeleteDeviceTokenUseCase.Command) {
         val token = Token(command.token)
         val deviceToken = deviceTokenQueryPort.getByToken(token)
-        deviceToken.validateOwner(command.userId)
-        deviceTokenCommandPort.deleteByToken(token)
+        val deletedDeviceToken = deviceToken.softDelete(command.userId)
+        deviceTokenCommandPort.saveDeviceToken(deletedDeviceToken)
     }
 }

--- a/core/src/main/kotlin/kr/wooco/woocobe/core/notification/domain/entity/DeviceToken.kt
+++ b/core/src/main/kotlin/kr/wooco/woocobe/core/notification/domain/entity/DeviceToken.kt
@@ -1,14 +1,21 @@
 package kr.wooco.woocobe.core.notification.domain.entity
 
 import kr.wooco.woocobe.core.notification.domain.exception.InvalidDeviceTokenOwnerException
+import kr.wooco.woocobe.core.notification.domain.vo.DeviceTokenStatus
 import kr.wooco.woocobe.core.notification.domain.vo.Token
 
 data class DeviceToken(
     val id: Long,
     val userId: Long,
     val token: Token,
+    val status: DeviceTokenStatus,
 ) {
-    fun validateOwner(userId: Long) {
+    fun softDelete(userId: Long): DeviceToken {
+        validateOwner(userId)
+        return copy(status = DeviceTokenStatus.DELETED)
+    }
+
+    private fun validateOwner(userId: Long) {
         if (this.userId != userId) throw InvalidDeviceTokenOwnerException
     }
 
@@ -21,6 +28,7 @@ data class DeviceToken(
                 id = 0L,
                 userId = userId,
                 token = token,
+                status = DeviceTokenStatus.ACTIVE,
             )
     }
 }

--- a/core/src/main/kotlin/kr/wooco/woocobe/core/notification/domain/entity/Notification.kt
+++ b/core/src/main/kotlin/kr/wooco/woocobe/core/notification/domain/entity/Notification.kt
@@ -2,6 +2,7 @@ package kr.wooco.woocobe.core.notification.domain.entity
 
 import kr.wooco.woocobe.core.notification.domain.exception.InvalidNotificationOwnerException
 import kr.wooco.woocobe.core.notification.domain.vo.NotificationReadStatus
+import kr.wooco.woocobe.core.notification.domain.vo.NotificationStatus
 import kr.wooco.woocobe.core.notification.domain.vo.NotificationType
 import java.time.LocalDateTime
 
@@ -12,11 +13,20 @@ data class Notification(
     val targetName: String,
     val type: NotificationType,
     val createdAt: LocalDateTime,
+    val status: NotificationStatus,
     val readStatus: NotificationReadStatus,
 ) {
-    fun markAsRead() = copy(readStatus = NotificationReadStatus.READ)
+    fun markAsRead(userId: Long): Notification {
+        validateOwner(userId)
+        return copy(readStatus = NotificationReadStatus.READ)
+    }
 
-    fun validateOwner(userId: Long) {
+    fun softDelete(userId: Long): Notification {
+        validateOwner(userId)
+        return copy(status = NotificationStatus.DELETED)
+    }
+
+    private fun validateOwner(userId: Long) {
         if (this.userId != userId) throw InvalidNotificationOwnerException
     }
 
@@ -34,6 +44,7 @@ data class Notification(
                 targetName = targetName,
                 type = type,
                 createdAt = LocalDateTime.now(),
+                status = NotificationStatus.ACTIVE,
                 readStatus = NotificationReadStatus.UNREAD,
             )
     }

--- a/core/src/main/kotlin/kr/wooco/woocobe/core/notification/domain/vo/DeviceTokenStatus.kt
+++ b/core/src/main/kotlin/kr/wooco/woocobe/core/notification/domain/vo/DeviceTokenStatus.kt
@@ -1,0 +1,11 @@
+package kr.wooco.woocobe.core.notification.domain.vo
+
+enum class DeviceTokenStatus {
+    ACTIVE,
+    DELETED,
+    ;
+
+    companion object {
+        operator fun invoke(value: String) = DeviceTokenStatus.valueOf(value)
+    }
+}

--- a/core/src/main/kotlin/kr/wooco/woocobe/core/notification/domain/vo/NotificationStatus.kt
+++ b/core/src/main/kotlin/kr/wooco/woocobe/core/notification/domain/vo/NotificationStatus.kt
@@ -1,0 +1,11 @@
+package kr.wooco.woocobe.core.notification.domain.vo
+
+enum class NotificationStatus {
+    ACTIVE,
+    DELETED,
+    ;
+
+    companion object {
+        operator fun invoke(value: String) = NotificationStatus.valueOf(value)
+    }
+}

--- a/core/src/main/kotlin/kr/wooco/woocobe/core/plan/application/port/out/PlanCommandPort.kt
+++ b/core/src/main/kotlin/kr/wooco/woocobe/core/plan/application/port/out/PlanCommandPort.kt
@@ -5,5 +5,5 @@ import kr.wooco.woocobe.core.plan.domain.entity.Plan
 interface PlanCommandPort {
     fun savePlan(plan: Plan): Plan
 
-    fun deleteByPlanId(planId: Long)
+    fun deleteAllPlanPlaceByPlanId(planId: Long)
 }

--- a/core/src/main/kotlin/kr/wooco/woocobe/core/plan/application/service/PlanCommandService.kt
+++ b/core/src/main/kotlin/kr/wooco/woocobe/core/plan/application/service/PlanCommandService.kt
@@ -55,7 +55,8 @@ internal class PlanCommandService(
     @Transactional
     override fun deletePlan(command: DeletePlanUseCase.Command) {
         val plan = planQueryPort.getByPlanId(command.planId)
-        plan.validateWriter(command.userId)
-        planCommandPort.deleteByPlanId(plan.id)
+        val deletedPlan = plan.softDelete(command.userId)
+        planCommandPort.savePlan(deletedPlan)
+        planCommandPort.deleteAllPlanPlaceByPlanId(plan.id)
     }
 }

--- a/core/src/main/kotlin/kr/wooco/woocobe/core/plan/domain/entity/Plan.kt
+++ b/core/src/main/kotlin/kr/wooco/woocobe/core/plan/domain/entity/Plan.kt
@@ -3,6 +3,7 @@ package kr.wooco.woocobe.core.plan.domain.entity
 import kr.wooco.woocobe.core.plan.domain.exception.InvalidPlanWriterException
 import kr.wooco.woocobe.core.plan.domain.vo.PlanPlace
 import kr.wooco.woocobe.core.plan.domain.vo.PlanRegion
+import kr.wooco.woocobe.core.plan.domain.vo.PlanStatus
 import java.time.LocalDate
 
 data class Plan(
@@ -13,6 +14,7 @@ data class Plan(
     val region: PlanRegion,
     val visitDate: LocalDate,
     val places: List<PlanPlace>,
+    val status: PlanStatus,
 ) {
     fun update(
         userId: Long,
@@ -32,7 +34,12 @@ data class Plan(
         )
     }
 
-    fun validateWriter(userId: Long) {
+    fun softDelete(userId: Long): Plan {
+        validateWriter(userId)
+        return copy(status = PlanStatus.DELETED)
+    }
+
+    private fun validateWriter(userId: Long) {
         if (this.userId != userId) throw InvalidPlanWriterException
     }
 
@@ -53,6 +60,7 @@ data class Plan(
                 region = region,
                 visitDate = visitDate,
                 places = processPlanPlaceOrder(placeIds),
+                status = PlanStatus.ACTIVE,
             )
 
         private fun processPlanPlaceOrder(placeIds: List<Long>): List<PlanPlace> =

--- a/core/src/main/kotlin/kr/wooco/woocobe/core/plan/domain/vo/PlanStatus.kt
+++ b/core/src/main/kotlin/kr/wooco/woocobe/core/plan/domain/vo/PlanStatus.kt
@@ -1,0 +1,11 @@
+package kr.wooco.woocobe.core.plan.domain.vo
+
+enum class PlanStatus {
+    ACTIVE,
+    DELETED,
+    ;
+
+    companion object {
+        operator fun invoke(value: String) = PlanStatus.valueOf(value)
+    }
+}

--- a/infrastructure/mysql/src/main/kotlin/kr/wooco/woocobe/mysql/notification/DeviceTokenJpaAdapter.kt
+++ b/infrastructure/mysql/src/main/kotlin/kr/wooco/woocobe/mysql/notification/DeviceTokenJpaAdapter.kt
@@ -9,26 +9,22 @@ import kr.wooco.woocobe.mysql.notification.repository.DeviceTokenJpaRepository
 import org.springframework.stereotype.Component
 
 @Component
-internal class DeviceTokenPersistenceAdapter(
+internal class DeviceTokenJpaAdapter(
     private val deviceTokenJpaRepository: DeviceTokenJpaRepository,
 ) : DeviceTokenQueryPort,
     DeviceTokenCommandPort {
     override fun getByToken(token: Token): DeviceToken {
-        val deviceTokenJpaEntity = deviceTokenJpaRepository.findByToken(token.value)
+        val deviceTokenJpaEntity = deviceTokenJpaRepository.findActiveByToken(token.value)
             ?: throw NotExistsDeviceTokenException
-        return DeviceTokenPersistenceMapper.toDomainEntity(deviceTokenJpaEntity)
+        return DeviceTokenJpaMapper.toDomainEntity(deviceTokenJpaEntity)
     }
 
     override fun getAllByUserId(userId: Long): List<DeviceToken> =
-        deviceTokenJpaRepository.findAllByUserId(userId).map { DeviceTokenPersistenceMapper.toDomainEntity(it) }
+        deviceTokenJpaRepository.findAllActiveByUserId(userId).map { DeviceTokenJpaMapper.toDomainEntity(it) }
 
     override fun saveDeviceToken(deviceToken: DeviceToken): DeviceToken {
-        val deviceTokenJpaEntity = DeviceTokenPersistenceMapper.toJpaEntity(deviceToken)
+        val deviceTokenJpaEntity = DeviceTokenJpaMapper.toJpaEntity(deviceToken)
         deviceTokenJpaRepository.save(deviceTokenJpaEntity)
-        return DeviceTokenPersistenceMapper.toDomainEntity(deviceTokenJpaEntity)
-    }
-
-    override fun deleteByToken(token: Token) {
-        deviceTokenJpaRepository.deleteByToken(token.value)
+        return DeviceTokenJpaMapper.toDomainEntity(deviceTokenJpaEntity)
     }
 }

--- a/infrastructure/mysql/src/main/kotlin/kr/wooco/woocobe/mysql/notification/DeviceTokenJpaMapper.kt
+++ b/infrastructure/mysql/src/main/kotlin/kr/wooco/woocobe/mysql/notification/DeviceTokenJpaMapper.kt
@@ -1,15 +1,17 @@
 package kr.wooco.woocobe.mysql.notification
 
 import kr.wooco.woocobe.core.notification.domain.entity.DeviceToken
+import kr.wooco.woocobe.core.notification.domain.vo.DeviceTokenStatus
 import kr.wooco.woocobe.core.notification.domain.vo.Token
 import kr.wooco.woocobe.mysql.notification.entity.DeviceTokenJpaEntity
 
-internal object DeviceTokenPersistenceMapper {
+internal object DeviceTokenJpaMapper {
     fun toDomainEntity(deviceTokenJpaEntity: DeviceTokenJpaEntity): DeviceToken =
         DeviceToken(
             id = deviceTokenJpaEntity.id,
             userId = deviceTokenJpaEntity.userId,
             token = Token(deviceTokenJpaEntity.token),
+            status = DeviceTokenStatus(deviceTokenJpaEntity.status),
         )
 
     fun toJpaEntity(deviceToken: DeviceToken): DeviceTokenJpaEntity =
@@ -17,5 +19,6 @@ internal object DeviceTokenPersistenceMapper {
             id = deviceToken.id,
             userId = deviceToken.userId,
             token = deviceToken.token.value,
+            status = deviceToken.status.name,
         )
 }

--- a/infrastructure/mysql/src/main/kotlin/kr/wooco/woocobe/mysql/notification/NotificationJpaAdapter.kt
+++ b/infrastructure/mysql/src/main/kotlin/kr/wooco/woocobe/mysql/notification/NotificationJpaAdapter.kt
@@ -5,26 +5,25 @@ import kr.wooco.woocobe.core.notification.application.port.out.NotificationQuery
 import kr.wooco.woocobe.core.notification.domain.entity.Notification
 import kr.wooco.woocobe.core.notification.domain.exception.NotExistsNotificationException
 import kr.wooco.woocobe.mysql.notification.repository.NotificationJpaRepository
-import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Component
 
 @Component
-internal class NotificationPersistenceAdapter(
+internal class NotificationJpaAdapter(
     private val notificationJpaRepository: NotificationJpaRepository,
 ) : NotificationQueryPort,
     NotificationCommandPort {
     override fun getByNotificationId(id: Long): Notification {
-        val notificationJpaEntity = notificationJpaRepository.findByIdOrNull(id)
+        val notificationJpaEntity = notificationJpaRepository.findActiveById(id)
             ?: throw NotExistsNotificationException
-        return NotificationPersistenceMapper.toDomainEntity(notificationJpaEntity)
+        return NotificationJpaMapper.toDomainEntity(notificationJpaEntity)
     }
 
     override fun getAllByUserId(userId: Long): List<Notification> =
-        notificationJpaRepository.findAllByUserId(userId).map { NotificationPersistenceMapper.toDomainEntity(it) }
+        notificationJpaRepository.findAllActiveByUserId(userId).map { NotificationJpaMapper.toDomainEntity(it) }
 
     override fun saveNotification(notification: Notification): Notification {
-        val notificationJpaEntity = NotificationPersistenceMapper.toJpaEntity(notification)
+        val notificationJpaEntity = NotificationJpaMapper.toJpaEntity(notification)
         notificationJpaRepository.save(notificationJpaEntity)
-        return NotificationPersistenceMapper.toDomainEntity(notificationJpaEntity)
+        return NotificationJpaMapper.toDomainEntity(notificationJpaEntity)
     }
 }

--- a/infrastructure/mysql/src/main/kotlin/kr/wooco/woocobe/mysql/notification/NotificationJpaMapper.kt
+++ b/infrastructure/mysql/src/main/kotlin/kr/wooco/woocobe/mysql/notification/NotificationJpaMapper.kt
@@ -2,19 +2,21 @@ package kr.wooco.woocobe.mysql.notification
 
 import kr.wooco.woocobe.core.notification.domain.entity.Notification
 import kr.wooco.woocobe.core.notification.domain.vo.NotificationReadStatus
+import kr.wooco.woocobe.core.notification.domain.vo.NotificationStatus
 import kr.wooco.woocobe.core.notification.domain.vo.NotificationType
 import kr.wooco.woocobe.mysql.notification.entity.NotificationJpaEntity
 
-internal object NotificationPersistenceMapper {
+internal object NotificationJpaMapper {
     fun toDomainEntity(notificationJpaEntity: NotificationJpaEntity): Notification =
         Notification(
             id = notificationJpaEntity.id,
             userId = notificationJpaEntity.userId,
             targetId = notificationJpaEntity.targetId,
             targetName = notificationJpaEntity.targetName,
-            type = NotificationType.invoke(notificationJpaEntity.type),
+            type = NotificationType(notificationJpaEntity.type),
             createdAt = notificationJpaEntity.createdAt,
-            readStatus = NotificationReadStatus.invoke(notificationJpaEntity.readStatus),
+            status = NotificationStatus(notificationJpaEntity.status),
+            readStatus = NotificationReadStatus(notificationJpaEntity.readStatus),
         )
 
     fun toJpaEntity(notification: Notification): NotificationJpaEntity =
@@ -24,6 +26,7 @@ internal object NotificationPersistenceMapper {
             targetId = notification.targetId,
             targetName = notification.targetName,
             type = notification.type.name,
+            status = notification.status.name,
             readStatus = notification.readStatus.name,
         )
 }

--- a/infrastructure/mysql/src/main/kotlin/kr/wooco/woocobe/mysql/notification/entity/DeviceTokenJpaEntity.kt
+++ b/infrastructure/mysql/src/main/kotlin/kr/wooco/woocobe/mysql/notification/entity/DeviceTokenJpaEntity.kt
@@ -14,6 +14,8 @@ class DeviceTokenJpaEntity(
     val token: String,
     @Column(name = "user_id")
     val userId: Long,
+    @Column(name = "status")
+    val status: String,
     @Id @Tsid
     @Column(name = "device_token_id")
     override val id: Long = 0L,

--- a/infrastructure/mysql/src/main/kotlin/kr/wooco/woocobe/mysql/notification/entity/NotificationJpaEntity.kt
+++ b/infrastructure/mysql/src/main/kotlin/kr/wooco/woocobe/mysql/notification/entity/NotificationJpaEntity.kt
@@ -18,6 +18,8 @@ class NotificationJpaEntity(
     val targetName: String,
     @Column(name = "type")
     val type: String,
+    @Column(name = "status")
+    val status: String,
     @Column(name = "read_status")
     val readStatus: String,
     @Id @Tsid

--- a/infrastructure/mysql/src/main/kotlin/kr/wooco/woocobe/mysql/notification/repository/DeviceTokenJpaRepository.kt
+++ b/infrastructure/mysql/src/main/kotlin/kr/wooco/woocobe/mysql/notification/repository/DeviceTokenJpaRepository.kt
@@ -2,11 +2,27 @@ package kr.wooco.woocobe.mysql.notification.repository
 
 import kr.wooco.woocobe.mysql.notification.entity.DeviceTokenJpaEntity
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 
 interface DeviceTokenJpaRepository : JpaRepository<DeviceTokenJpaEntity, Long> {
-    fun findByToken(token: String): DeviceTokenJpaEntity?
+    @Query(
+        """
+            SELECT d FROM DeviceTokenJpaEntity d
+            WHERE d.token = :token
+            AND d.status = 'ACTIVE'
+        """,
+    )
+    fun findActiveByToken(token: String): DeviceTokenJpaEntity?
 
-    fun findAllByUserId(userId: Long): List<DeviceTokenJpaEntity>
-
-    fun deleteByToken(token: String)
+    @Query(
+        """
+            SELECT d FROM DeviceTokenJpaEntity d
+            WHERE d.userId = :userId
+            AND d.status = 'ACTIVE'
+        """,
+    )
+    fun findAllActiveByUserId(
+        @Param("userId") userId: Long,
+    ): List<DeviceTokenJpaEntity>
 }

--- a/infrastructure/mysql/src/main/kotlin/kr/wooco/woocobe/mysql/notification/repository/NotificationJpaRepository.kt
+++ b/infrastructure/mysql/src/main/kotlin/kr/wooco/woocobe/mysql/notification/repository/NotificationJpaRepository.kt
@@ -2,7 +2,27 @@ package kr.wooco.woocobe.mysql.notification.repository
 
 import kr.wooco.woocobe.mysql.notification.entity.NotificationJpaEntity
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 
 interface NotificationJpaRepository : JpaRepository<NotificationJpaEntity, Long> {
-    fun findAllByUserId(userId: Long): List<NotificationJpaEntity>
+    @Query(
+        """
+            SELECT n FROM NotificationJpaEntity n
+            WHERE n.id = :notificationId
+            AND n.status = 'ACTIVE'
+        """,
+    )
+    fun findActiveById(
+        @Param("notificationId") notificationId: Long,
+    ): NotificationJpaEntity?
+
+    @Query(
+        """
+            SELECT n FROM NotificationJpaEntity n
+            WHERE n.userId = :userId
+            AND n.status = 'ACTIVE'
+        """,
+    )
+    fun findAllActiveByUserId(userId: Long): List<NotificationJpaEntity>
 }

--- a/infrastructure/mysql/src/main/kotlin/kr/wooco/woocobe/mysql/plan/PlanJpaMapper.kt
+++ b/infrastructure/mysql/src/main/kotlin/kr/wooco/woocobe/mysql/plan/PlanJpaMapper.kt
@@ -3,10 +3,11 @@ package kr.wooco.woocobe.mysql.plan
 import kr.wooco.woocobe.core.plan.domain.entity.Plan
 import kr.wooco.woocobe.core.plan.domain.vo.PlanPlace
 import kr.wooco.woocobe.core.plan.domain.vo.PlanRegion
+import kr.wooco.woocobe.core.plan.domain.vo.PlanStatus
 import kr.wooco.woocobe.mysql.plan.entity.PlanJpaEntity
 import kr.wooco.woocobe.mysql.plan.entity.PlanPlaceJpaEntity
 
-internal object PlanPersistenceMapper {
+internal object PlanJpaMapper {
     fun toDomainEntity(
         planJpaEntity: PlanJpaEntity,
         planPlaceJpaEntities: List<PlanPlaceJpaEntity>,
@@ -22,6 +23,7 @@ internal object PlanPersistenceMapper {
             ),
             visitDate = planJpaEntity.visitDate,
             places = planPlaceJpaEntities.map { PlanPlace(order = it.order, placeId = it.placeId) },
+            status = PlanStatus(planJpaEntity.status),
         )
 
     fun toJpaEntity(plan: Plan): PlanJpaEntity =
@@ -33,5 +35,6 @@ internal object PlanPersistenceMapper {
             primaryRegion = plan.region.primaryRegion,
             secondaryRegion = plan.region.secondaryRegion,
             visitDate = plan.visitDate,
+            status = plan.status.name,
         )
 }

--- a/infrastructure/mysql/src/main/kotlin/kr/wooco/woocobe/mysql/plan/PlanPlaceJpaMapper.kt
+++ b/infrastructure/mysql/src/main/kotlin/kr/wooco/woocobe/mysql/plan/PlanPlaceJpaMapper.kt
@@ -3,7 +3,7 @@ package kr.wooco.woocobe.mysql.plan
 import kr.wooco.woocobe.core.plan.domain.vo.PlanPlace
 import kr.wooco.woocobe.mysql.plan.entity.PlanPlaceJpaEntity
 
-internal object PlanPlacePersistenceMapper {
+internal object PlanPlaceJpaMapper {
     fun toJpaEntity(
         planId: Long,
         planPlace: PlanPlace,

--- a/infrastructure/mysql/src/main/kotlin/kr/wooco/woocobe/mysql/plan/entity/PlanJpaEntity.kt
+++ b/infrastructure/mysql/src/main/kotlin/kr/wooco/woocobe/mysql/plan/entity/PlanJpaEntity.kt
@@ -23,6 +23,8 @@ class PlanJpaEntity(
     val secondaryRegion: String,
     @Column(name = "visit_date")
     val visitDate: LocalDate,
+    @Column(name = "status")
+    val status: String,
     @Id @Tsid
     @Column(name = "plan_id")
     override val id: Long = 0L,

--- a/infrastructure/mysql/src/main/kotlin/kr/wooco/woocobe/mysql/plan/repository/PlanJpaRepository.kt
+++ b/infrastructure/mysql/src/main/kotlin/kr/wooco/woocobe/mysql/plan/repository/PlanJpaRepository.kt
@@ -7,15 +7,36 @@ import org.springframework.data.repository.query.Param
 import java.time.LocalDateTime
 
 interface PlanJpaRepository : JpaRepository<PlanJpaEntity, Long> {
-    fun findAllByUserId(userId: Long): List<PlanJpaEntity>
+    @Query(
+        """
+            SELECT p FROM PlanJpaEntity p
+            WHERE p.id = :planId
+            AND p.status = 'ACTIVE'
+        """,
+    )
+    fun findActiveById(
+        @Param("planId") planId: Long,
+    ): PlanJpaEntity?
+
+    @Query(
+        """
+            SELECT p FROM PlanJpaEntity p
+            WHERE p.userId = :userId
+            AND p.status = 'ACTIVE'
+        """,
+    )
+    fun findAllActiveByUserId(
+        @Param("userId") userId: Long,
+    ): List<PlanJpaEntity>
 
     @Query(
         """
             SELECT p FROM PlanJpaEntity p
             WHERE p.createdAt BETWEEN :startDate AND :endDate
+            AND p.status = 'ACTIVE'
         """,
     )
-    fun findAllByCreatedAtBetween(
+    fun findAllActiveByCreatedAtBetween(
         @Param("startDate") startDate: LocalDateTime,
         @Param("endDate") endDate: LocalDateTime,
     ): List<PlanJpaEntity>

--- a/infrastructure/mysql/src/main/resources/db/migration/V4__add_status_notifications_and_plans.sql
+++ b/infrastructure/mysql/src/main/resources/db/migration/V4__add_status_notifications_and_plans.sql
@@ -1,0 +1,10 @@
+-- V4__add_status_notifications_and_plans.sql
+
+ALTER TABLE notifications
+    ADD COLUMN status varchar(20) NOT NULL DEFAULT 'ACTIVE';
+
+ALTER TABLE device_tokens
+    ADD COLUMN status varchar(20) NOT NULL DEFAULT 'ACTIVE';
+
+ALTER TABLE plans
+    ADD COLUMN status varchar(20) NOT NULL DEFAULT 'ACTIVE';


### PR DESCRIPTION
## 📝 개요

- 알림 및 플랜 도메인 `soft delete` 적용
- 기타 매퍼, 어댑터 네이밍 등 컨벤션 통일

## ✨ 변경 사항

- ✨ `notifications`, `device_tokens`, `plans` 테이블에 `status` 필드를 추가함에 따라 flyway 마이그레이션 파일을 추가했습니다.
- ✨ 각 도메인 엔티티에서 `soft delete`를 위한 메서드를 추가, 커멘드 서비스에서 이를 호출하도록 변경했습니다.
- ✨ 각 레포지토리의 조회 쿼리에 `ACTIVE` 상태 조건을 추가했습니다. 
- ✨ 기존 `xxxPersistenceMapper`, `xxxPersistenceAdapter` 네이밍을 `xxxJpaMapper`, `xxxJpaAdapter`로 변경했습니다.
- ✨ 각 도메인 엔티티의 `validateOwner()` 메서드를 private 으로 변경했습니다.

## 🔗 관련 이슈

- closed #202

## ℹ️ 참고 사항

- 현재 `soft delete` 적용시 도메인 클래스에서 상태를 바꾸고, 커멘드 서비스에서 이를 `save`메서드로  저장합니다. 만약 더 좋은 방법이 있다면 알려주세요!!!
- `Notification` 은 직접적으로 삭제하는 기능이 없어 도메인 클래스 내에서 `soft delete` 메서드만 구현하고, 이를 위한 엔드포인트는 만들지 않았습니다. 만약 추가될 경우 컨트롤러에서만 추가하면 됩니다.
