### PR TITLE
refactor: 이벤트 발행 로직 개선

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -10,4 +10,5 @@ dependencies {
     implementation(project(":support:common"))
 
     implementation("org.springframework:spring-tx")
+    implementation("org.springframework:spring-aspects")
 }

--- a/core/src/main/kotlin/kr/wooco/woocobe/core/common/aspect/EventPublisherAspect.kt
+++ b/core/src/main/kotlin/kr/wooco/woocobe/core/common/aspect/EventPublisherAspect.kt
@@ -1,0 +1,55 @@
+package kr.wooco.woocobe.core.common.aspect
+
+import kr.wooco.woocobe.common.event.EventContext
+import org.aspectj.lang.ProceedingJoinPoint
+import org.aspectj.lang.annotation.Around
+import org.aspectj.lang.annotation.Aspect
+import org.aspectj.lang.annotation.Pointcut
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.stereotype.Component
+
+@Aspect
+@Component
+class EventPublisherAspect(
+    private val applicationEventPublisher: ApplicationEventPublisher,
+) {
+    @Pointcut("within(kr.wooco.woocobe.core..*)")
+    fun withinCoreModule() {
+    }
+
+    @Pointcut("@within(org.springframework.stereotype.Service)")
+    fun hasServiceAnnotation() {
+    }
+
+    /**
+     * 도메인 이벤트가 등록된 후 영속화 레이어에서 영속화 메서드를 명시적으로 호출하지 않아
+     * 발행되지 못한 잔여 이벤트를 발행합니다.
+     *
+     * 또한, 이 AOP 는 [kr.wooco.woocobe.core] 모듈 내의
+     * [org.springframework.stereotype.Service] 어노테이션이 있는 클래스에만 적용되며,
+     * AOP 실행 전 이전 요청 또는 중첩 호출 등에서 인해 남아 있을 수도 있는 잔여 이벤트를 초기화합니다.
+     *
+     * 따라서, 도메인 핸들링 후 영속화 레이어 내에서 명시적으로 영속화 메서드 `save()` 호출을 권장합니다.
+     *
+     * **NOTE** : 서비스 로직 수행중 예외가 발생시, 등록된 이벤트들은 발행되지 않으며 초기화됩니다.
+     *
+     * @see kr.wooco.woocobe.common.event.EventContext
+     * @see kr.wooco.woocobe.mysql.common.advice.EventPublishingMethodInterceptor
+     * @author JiHongKim98
+     */
+    @Around("withinCoreModule() && hasServiceAnnotation()")
+    fun execute(joinPoint: ProceedingJoinPoint): Any? {
+        EventContext.clearEvents()
+
+        return runCatching {
+            joinPoint.proceed()
+        }.onSuccess {
+            EventContext.raiseEvents { event ->
+                applicationEventPublisher.publishEvent(event)
+            }
+        }.onFailure { throwable ->
+            EventContext.clearEvents()
+            throw throwable
+        }
+    }
+}

--- a/core/src/main/kotlin/kr/wooco/woocobe/core/common/domain/entity/AggregateRoot.kt
+++ b/core/src/main/kotlin/kr/wooco/woocobe/core/common/domain/entity/AggregateRoot.kt
@@ -1,0 +1,19 @@
+package kr.wooco.woocobe.core.common.domain.entity
+
+import kr.wooco.woocobe.common.event.EventContext
+import kr.wooco.woocobe.core.common.domain.event.DomainEvent
+
+abstract class AggregateRoot : DomainEntity() {
+    /**
+     * [EventContext]의 이벤트 저장소에 새로운 도메인 이벤트를 등록합니다.
+     *
+     * **Note** : [registerEvent] 메서드는 이벤트를 발행하지 않고, [EventContext]의 이벤트 저장소에 이벤트 등록만 진행합니다.
+     *
+     * @see kr.wooco.woocobe.common.event.EventContext
+     * @param domainEvent [DomainEvent]
+     * @author JiHongKim98
+     */
+    protected fun registerEvent(domainEvent: DomainEvent) {
+        EventContext.appendEvent(domainEvent)
+    }
+}

--- a/core/src/main/kotlin/kr/wooco/woocobe/core/common/domain/entity/DomainEntity.kt
+++ b/core/src/main/kotlin/kr/wooco/woocobe/core/common/domain/entity/DomainEntity.kt
@@ -1,0 +1,31 @@
+package kr.wooco.woocobe.core.common.domain.entity
+
+import kr.wooco.woocobe.common.tsid.TsidGenerator
+
+abstract class DomainEntity {
+    abstract val id: Long
+
+    override fun hashCode(): Int = id.hashCode()
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as DomainEntity
+
+        return id == other.id
+    }
+
+    override fun toString(): String = "${this::class.simpleName}(id=$id)"
+
+    companion object {
+        /**
+         * Long 타입의 TSID를 생성합니다.
+         *
+         * @return Long
+         * @author JiHongKim98
+         */
+        @JvmStatic
+        protected fun generateId(): Long = TsidGenerator.generateToLong()
+    }
+}

--- a/core/src/main/kotlin/kr/wooco/woocobe/core/common/domain/event/DomainEvent.kt
+++ b/core/src/main/kotlin/kr/wooco/woocobe/core/common/domain/event/DomainEvent.kt
@@ -1,0 +1,7 @@
+package kr.wooco.woocobe.core.common.domain.event
+
+import kr.wooco.woocobe.common.event.Event
+
+abstract class DomainEvent : Event() {
+    abstract val aggregateId: Long
+}

--- a/infrastructure/mysql/src/main/kotlin/kr/wooco/woocobe/mysql/common/advice/CustomJpaRepositoryFactoryBean.kt
+++ b/infrastructure/mysql/src/main/kotlin/kr/wooco/woocobe/mysql/common/advice/CustomJpaRepositoryFactoryBean.kt
@@ -1,0 +1,31 @@
+package kr.wooco.woocobe.mysql.common.advice
+
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.context.ApplicationEventPublisherAware
+import org.springframework.data.jpa.repository.support.JpaRepositoryFactoryBean
+import org.springframework.data.repository.Repository
+import org.springframework.data.repository.core.support.RepositoryFactorySupport
+
+class CustomJpaRepositoryFactoryBean<T : Repository<S, ID>, S, ID>(
+    repositoryInterface: Class<out T>,
+) : JpaRepositoryFactoryBean<T, S, ID>(repositoryInterface),
+    ApplicationEventPublisherAware {
+    private lateinit var applicationEventPublisher: ApplicationEventPublisher
+
+    override fun setApplicationEventPublisher(applicationEventPublisher: ApplicationEventPublisher) {
+        this.applicationEventPublisher = applicationEventPublisher
+    }
+
+    override fun doCreateRepositoryFactory(): RepositoryFactorySupport {
+        val repositoryFactorySupport = super.doCreateRepositoryFactory()
+
+        addEventPublishMethodInterceptor(repositoryFactorySupport)
+
+        return repositoryFactorySupport
+    }
+
+    private fun addEventPublishMethodInterceptor(repositoryFactorySupport: RepositoryFactorySupport) =
+        repositoryFactorySupport.addRepositoryProxyPostProcessor { factory, _ ->
+            factory.addAdvice(EventPublishingMethodInterceptor(applicationEventPublisher))
+        }
+}

--- a/infrastructure/mysql/src/main/kotlin/kr/wooco/woocobe/mysql/common/advice/EventPublishingMethodInterceptor.kt
+++ b/infrastructure/mysql/src/main/kotlin/kr/wooco/woocobe/mysql/common/advice/EventPublishingMethodInterceptor.kt
@@ -1,0 +1,42 @@
+package kr.wooco.woocobe.mysql.common.advice
+
+import kr.wooco.woocobe.common.event.EventContext
+import org.aopalliance.intercept.MethodInterceptor
+import org.aopalliance.intercept.MethodInvocation
+import org.springframework.context.ApplicationEventPublisher
+import java.lang.reflect.Method
+
+/**
+ * Spring Data JPA의 영속화 메서드 호출 이후, 도메인 엔티티내에서 등록된 이벤트를
+ * [EventContext]에서 가져와 실제로 이벤트를 발행시키는 메서드 인터셉터입니다.
+ *
+ * Spring data의 [org.springframework.data.domain.AbstractAggregateRoot]를 사용한다면,
+ * 삭제 관련 메서드에서도 이벤트를 발행하지만, 우리 프로젝트에서는 `save()` 관련 메서드에서만 이벤트를 발행합니다.
+ *
+ * 참고 : [org.springframework.data.repository.core.support.EventPublishingRepositoryProxyPostProcessor]
+ *
+ * @see kr.wooco.woocobe.common.event.EventContext
+ * @author JiHongKim98
+ */
+class EventPublishingMethodInterceptor(
+    private val applicationEventPublisher: ApplicationEventPublisher,
+) : MethodInterceptor {
+    override fun invoke(invocation: MethodInvocation): Any? {
+        val result = invocation.proceed()
+        if (isEventPublishingMethod(invocation.method)) {
+            EventContext.raiseEvents { event ->
+                applicationEventPublisher.publishEvent(event)
+            }
+        }
+        return result
+    }
+
+    private fun isEventPublishingMethod(method: Method): Boolean {
+        val methodName = method.name
+        return methodName.startsWith(SAVE_METHOD_PREFIX)
+    }
+
+    companion object {
+        private const val SAVE_METHOD_PREFIX = "save"
+    }
+}

--- a/infrastructure/mysql/src/main/kotlin/kr/wooco/woocobe/mysql/common/config/MysqlConfig.kt
+++ b/infrastructure/mysql/src/main/kotlin/kr/wooco/woocobe/mysql/common/config/MysqlConfig.kt
@@ -1,5 +1,6 @@
 package kr.wooco.woocobe.mysql.common.config
 
+import kr.wooco.woocobe.mysql.common.advice.CustomJpaRepositoryFactoryBean
 import org.springframework.boot.autoconfigure.domain.EntityScan
 import org.springframework.context.annotation.ComponentScan
 import org.springframework.context.annotation.Configuration
@@ -8,5 +9,8 @@ import org.springframework.data.jpa.repository.config.EnableJpaRepositories
 @Configuration
 @EntityScan(basePackages = ["kr.wooco.woocobe.mysql"])
 @ComponentScan(basePackages = ["kr.wooco.woocobe.mysql"])
-@EnableJpaRepositories(basePackages = ["kr.wooco.woocobe.mysql"])
+@EnableJpaRepositories(
+    basePackages = ["kr.wooco.woocobe.mysql"],
+    repositoryFactoryBeanClass = CustomJpaRepositoryFactoryBean::class,
+)
 class MysqlConfig

--- a/infrastructure/mysql/src/main/kotlin/kr/wooco/woocobe/mysql/common/entity/BaseEntity.kt
+++ b/infrastructure/mysql/src/main/kotlin/kr/wooco/woocobe/mysql/common/entity/BaseEntity.kt
@@ -2,15 +2,27 @@ package kr.wooco.woocobe.mysql.common.entity
 
 import jakarta.persistence.MappedSuperclass
 import org.hibernate.proxy.HibernateProxy
-import org.springframework.data.domain.Persistable
 
 @MappedSuperclass
-abstract class BaseEntity : Persistable<Long> {
+abstract class BaseEntity {
     abstract val id: Long
 
-    override fun getId(): Long = id
+// FIXME & NOTE : id 생성 로직이 모두 도메인 엔티티측으로 위임되면 아래 주석 풀어주십쇼!!
+// : Persistable<Long> {
 
-    override fun isNew(): Boolean = id == 0L
+//    @Suppress("ktlint:standard:backing-property-naming")
+//    @Transient
+//    private var _isNew: Boolean = true
+
+//    override fun getId(): Long = id
+
+//    override fun isNew(): Boolean = _isNew
+
+//    @PostLoad
+//    @PostPersist
+//    protected fun markNotNew() {
+//        _isNew = false
+//    }
 
     override fun equals(other: Any?): Boolean {
         if (other == null) return false

--- a/infrastructure/mysql/src/main/kotlin/kr/wooco/woocobe/mysql/common/utils/Tsid.kt
+++ b/infrastructure/mysql/src/main/kotlin/kr/wooco/woocobe/mysql/common/utils/Tsid.kt
@@ -1,6 +1,7 @@
 package kr.wooco.woocobe.mysql.common.utils
 
 import kr.wooco.woocobe.common.tsid.TsidGenerator
+import kr.wooco.woocobe.mysql.common.entity.BaseEntity
 import org.hibernate.annotations.IdGeneratorType
 import org.hibernate.engine.spi.SharedSessionContractImplementor
 import org.hibernate.id.IdentifierGenerator
@@ -9,9 +10,15 @@ internal class TsidIdentifierGenerator : IdentifierGenerator {
     override fun generate(
         session: SharedSessionContractImplementor?,
         `object`: Any?,
-    ): Any = TsidGenerator.generateToLong()
+    ): Any {
+        if (`object` is BaseEntity && `object`.id != 0L) {
+            return `object`.id
+        }
+        return TsidGenerator.generateToLong()
+    }
 }
 
+@Deprecated(message = "엔티티의 식별자 생성 전략은 domain 엔티티 측으로 옮겨주세요.")
 @IdGeneratorType(TsidIdentifierGenerator::class)
 @Target(AnnotationTarget.FIELD, AnnotationTarget.FUNCTION)
 @Retention(AnnotationRetention.RUNTIME)

--- a/support/common/src/main/kotlin/kr/wooco/woocobe/common/event/Event.kt
+++ b/support/common/src/main/kotlin/kr/wooco/woocobe/common/event/Event.kt
@@ -1,0 +1,7 @@
+package kr.wooco.woocobe.common.event
+
+import java.util.UUID
+
+abstract class Event {
+    val eventId: String = UUID.randomUUID().toString()
+}

--- a/support/common/src/main/kotlin/kr/wooco/woocobe/common/event/EventContext.kt
+++ b/support/common/src/main/kotlin/kr/wooco/woocobe/common/event/EventContext.kt
@@ -1,0 +1,51 @@
+package kr.wooco.woocobe.common.event
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+
+private val log = KotlinLogging.logger {}
+
+object EventContext {
+    private val eventStore: ThreadLocal<MutableList<Event>> = ThreadLocal.withInitial { mutableListOf() }
+
+    /**
+     * 현재 ThreadLocal 내 이벤트를 저장합니다.
+     *
+     * @param event [Event]
+     * @author JiHongKim98
+     */
+    fun appendEvent(event: Event) = eventStore.get().add(event)
+
+    /**
+     * 현재 ThreadLocal 내 저장된 이벤트들을 순차적으로 발행 후 이벤트 저장소를 정리합니다.
+     *
+     * @param publisher 각 이벤트를 발행하기 위한 함수.
+     * @author JiHongKim98
+     */
+    fun raiseEvents(publisher: (Event) -> Unit) {
+        eventStore.get().forEach { event ->
+            publisher(event)
+        }
+        eventStore.remove()
+    }
+
+    /**
+     * 현재 ThreadLocal 내 이벤트 저장소를 정리합니다.
+     *
+     * @author JiHongKim98
+     */
+    fun clearEvents() {
+        if (log.isDebugEnabled()) {
+            tracePublishFailedEvents()
+        }
+        eventStore.remove()
+    }
+
+    private fun tracePublishFailedEvents() {
+        if (eventStore.get().isNotEmpty()) {
+            log.error { "${eventStore.get().size}개의 잔여 이벤트가 남았지만, 해당 이벤트가 발행되지 못하고 삭제 되었습니다." }
+            eventStore.get().forEach { event ->
+                log.error { "발행되지 못한 이벤트 (class :: ${event.javaClass.simpleName}) | (eventId :: ${event.eventId})" }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 📝 개요

<!-- 이 PR의 목적과 관련된 정보를 간략히 설명합니다. -->

이벤트 발행 로직을 개선합니다.

## ✨ 변경 사항

<!-- 코드나 기능의 주요 변경 사항을 설명 -->

- ✨ 쓰레드 개별 이벤트를 저장할 수 있는 EventContext 클래스 추가
- ✨ 기본 AggregateRoot 및 DomainEntity 클래스 추가
- ✨ 애플리케이션 레이어에서 명시적으로 `ApplicationEventPublisher` 를 사용하던 부분 개선
- ✨ Async 쓰레드에서 정상적으로 MDC 컨텍스트가 복사되지 않는 버그 해결

## 🔗 관련 이슈

<!-- 이 PR과 관련된 이슈 번호를 연결 (없으면 생략) -->

- closed #195 

## ℹ️ 참고 사항

<!-- 리뷰어가 알 필요가 있는 추가 정보나 문서, 참고 링크를 포함 (없으면 생략) -->

기존에 애플리케이션 레이어에서 `ApplicationEventPublisher` 를 통해 이벤트를 명시적으로 발행시켜 부자연스러웠던 부분을
도메인 엔티티에서 이벤트 등록 후 영속화가 완료된 뒤 이벤트가 인터셉터 또는 AOP를 통해 발행되도록 개선하였습니다.

동작 방식은 AggregateRoot 내 `registerEvent()` 메서드를 통해 
도메인 엔티티내에서 EventContext에 정의된 `eventStore` 즉,ThreadLocal 내 이벤트를 "등록"하며, 
Spring Data JPA의 `save()` 관련 메서드를 호출하거나 서비스 로직이 종료될때 이벤트가 "발행"됩니다.

도메인 엔티티 내에서는 이벤트 등록을, 도메인 외부에서 이벤트가 실제 발행되는 것을 인지하셔야합니다.

세부 내용은 EventContext, AggregateRoot 등 현 PR에서 추가된 클래스 안에 헷갈리지 않도록 주석을 달아놨습니다.