### PR TITLE
fix: FCM 전송시 디바이스 토큰이 없는 경우 발생하는 예외 해결

### DIFF
--- a/core/src/main/kotlin/kr/wooco/woocobe/core/notification/application/service/NotificationQueryService.kt
+++ b/core/src/main/kotlin/kr/wooco/woocobe/core/notification/application/service/NotificationQueryService.kt
@@ -25,6 +25,8 @@ class NotificationQueryService(
     override fun sendNotification(query: SendNotificationUseCase.Query) {
         val notification = notificationQueryPort.getByNotificationIdWithActive(query.notificationId)
         val tokens = deviceTokenQueryPort.getAllByUserIdWithActive(notification.userId).map { it.token }
-        notificationSenderPort.sendNotification(notification = notification, tokens = tokens)
+        if (tokens.isNotEmpty()) {
+            notificationSenderPort.sendNotification(notification = notification, tokens = tokens)
+        }
     }
 }

--- a/infrastructure/fcm/src/main/kotlin/kr/wooco/woocobe/fcm/notification/FcmNotificationSenderAdapter.kt
+++ b/infrastructure/fcm/src/main/kotlin/kr/wooco/woocobe/fcm/notification/FcmNotificationSenderAdapter.kt
@@ -16,10 +16,6 @@ internal class FcmNotificationSenderAdapter(
         notification: Notification,
         tokens: List<Token>,
     ) {
-        if (tokens.isEmpty()) {
-            log.warn { "FCM token is empty, userId: ${notification.userId}" }
-            return
-        }
         val messages = MulticastMessage
             .builder()
             .addAllTokens(tokens.map { it.value })

--- a/infrastructure/fcm/src/main/kotlin/kr/wooco/woocobe/fcm/notification/FcmNotificationSenderAdapter.kt
+++ b/infrastructure/fcm/src/main/kotlin/kr/wooco/woocobe/fcm/notification/FcmNotificationSenderAdapter.kt
@@ -16,6 +16,10 @@ internal class FcmNotificationSenderAdapter(
         notification: Notification,
         tokens: List<Token>,
     ) {
+        if (tokens.isEmpty()) {
+            log.warn { "FCM token is empty, userId: ${notification.userId}" }
+            return
+        }
         val messages = MulticastMessage
             .builder()
             .addAllTokens(tokens.map { it.value })


### PR DESCRIPTION
## 📝 개요

- FCM 알림 전송시 디바이스 토큰이 없는 경우 발생하는 예외를 핸들링하기 위한 PR입니다.

## ✨ 변경 사항

- ✨ 알림 전송 전 디바이스 토큰이 비어있다면 전송을 하지 않도록 조건 변경

## 🔗 관련 이슈

- closed #209

## ℹ️ 참고 사항

- 실시간 알림은 FCM, 알림 목록 조회는 DB 기반 API로 분리되어 있습니다. 따라서 `FCM 실패 = "실시간 전송 실패"` 일 뿐, 알림 자체는 유실되지 않기 때문에 특정 예외를 발생시키지 않고 해당 메서드를 종료하도록 구현했습니다. 
- 만약 추후에 전송 상태를 핸들링하도록 정책이 바뀐다면, 해당 상황에 맞게 리팩토링하면 될 것 같습니다. 이에 전송 실패시 디바이스 토큰이 없는 유저 아이디만 로그에 남기도록 했습니다.
