### PR TITLE
feat: 장소 상세 정보와 리뷰 리스트를 통합 조회하는 API 추가

### DIFF
--- a/bootstrap/api/src/main/kotlin/kr/wooco/woocobe/api/place/PlaceApi.kt
+++ b/bootstrap/api/src/main/kotlin/kr/wooco/woocobe/api/place/PlaceApi.kt
@@ -5,7 +5,7 @@ import io.swagger.v3.oas.annotations.tags.Tag
 import kr.wooco.woocobe.api.place.request.CreatePlaceRequest
 import kr.wooco.woocobe.api.place.response.CreatePlaceResponse
 import kr.wooco.woocobe.api.place.response.PlaceDetailResponse
-import kr.wooco.woocobe.api.place.response.PlaceWithPlaceReviewsDetailResponse
+import kr.wooco.woocobe.api.place.response.PlaceDetailWithPlaceReviewsResponse
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.PathVariable
@@ -25,5 +25,5 @@ interface PlaceApi {
 
     fun getPlaceDetailWithPlaceReview(
         @PathVariable placeId: Long,
-    ): ResponseEntity<PlaceWithPlaceReviewsDetailResponse>
+    ): ResponseEntity<PlaceDetailWithPlaceReviewsResponse>
 }

--- a/bootstrap/api/src/main/kotlin/kr/wooco/woocobe/api/place/PlaceApi.kt
+++ b/bootstrap/api/src/main/kotlin/kr/wooco/woocobe/api/place/PlaceApi.kt
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.tags.Tag
 import kr.wooco.woocobe.api.place.request.CreatePlaceRequest
 import kr.wooco.woocobe.api.place.response.CreatePlaceResponse
 import kr.wooco.woocobe.api.place.response.PlaceDetailResponse
+import kr.wooco.woocobe.api.place.response.PlaceWithPlaceReviewsDetailResponse
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.PathVariable
@@ -21,4 +22,8 @@ interface PlaceApi {
         @AuthenticationPrincipal userId: Long,
         @RequestBody request: CreatePlaceRequest,
     ): ResponseEntity<CreatePlaceResponse>
+
+    fun getPlaceDetailWithPlaceReview(
+        @PathVariable placeId: Long,
+    ): ResponseEntity<PlaceWithPlaceReviewsDetailResponse>
 }

--- a/bootstrap/api/src/main/kotlin/kr/wooco/woocobe/api/place/PlaceController.kt
+++ b/bootstrap/api/src/main/kotlin/kr/wooco/woocobe/api/place/PlaceController.kt
@@ -3,8 +3,10 @@ package kr.wooco.woocobe.api.place
 import kr.wooco.woocobe.api.place.request.CreatePlaceRequest
 import kr.wooco.woocobe.api.place.response.CreatePlaceResponse
 import kr.wooco.woocobe.api.place.response.PlaceDetailResponse
+import kr.wooco.woocobe.api.place.response.PlaceWithPlaceReviewsDetailResponse
 import kr.wooco.woocobe.core.place.application.port.`in`.CreatePlaceIfNotExistsUseCase
 import kr.wooco.woocobe.core.place.application.port.`in`.ReadPlaceUseCase
+import kr.wooco.woocobe.core.place.application.port.`in`.ReadPlaceWithPlaceReviewsUseCase
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
@@ -20,6 +22,7 @@ import org.springframework.web.bind.annotation.RestController
 class PlaceController(
     private val createPlaceIfNotExistsUseCase: CreatePlaceIfNotExistsUseCase,
     private val readPlaceUseCase: ReadPlaceUseCase,
+    private val readPlaceWithPlaceReviewsUseCase: ReadPlaceWithPlaceReviewsUseCase,
 ) : PlaceApi {
     @GetMapping("/{placeId}")
     override fun getPlaceDetail(
@@ -38,5 +41,14 @@ class PlaceController(
         val command = request.toCommand()
         val result = createPlaceIfNotExistsUseCase.createPlaceIfNotExists(command)
         return ResponseEntity.status(HttpStatus.CREATED).body(CreatePlaceResponse(result))
+    }
+
+    @GetMapping("/{placeId}/aggregation")
+    override fun getPlaceDetailWithPlaceReview(
+        @PathVariable placeId: Long,
+    ): ResponseEntity<PlaceWithPlaceReviewsDetailResponse> {
+        val query = ReadPlaceWithPlaceReviewsUseCase.Query(placeId)
+        val results = readPlaceWithPlaceReviewsUseCase.readPlaceWithPlaceReviews(query)
+        return ResponseEntity.ok(PlaceWithPlaceReviewsDetailResponse.from(results))
     }
 }

--- a/bootstrap/api/src/main/kotlin/kr/wooco/woocobe/api/place/PlaceController.kt
+++ b/bootstrap/api/src/main/kotlin/kr/wooco/woocobe/api/place/PlaceController.kt
@@ -3,7 +3,7 @@ package kr.wooco.woocobe.api.place
 import kr.wooco.woocobe.api.place.request.CreatePlaceRequest
 import kr.wooco.woocobe.api.place.response.CreatePlaceResponse
 import kr.wooco.woocobe.api.place.response.PlaceDetailResponse
-import kr.wooco.woocobe.api.place.response.PlaceWithPlaceReviewsDetailResponse
+import kr.wooco.woocobe.api.place.response.PlaceDetailWithPlaceReviewsResponse
 import kr.wooco.woocobe.core.place.application.port.`in`.CreatePlaceIfNotExistsUseCase
 import kr.wooco.woocobe.core.place.application.port.`in`.ReadPlaceUseCase
 import kr.wooco.woocobe.core.place.application.port.`in`.ReadPlaceWithPlaceReviewsUseCase
@@ -46,9 +46,9 @@ class PlaceController(
     @GetMapping("/{placeId}/aggregation")
     override fun getPlaceDetailWithPlaceReview(
         @PathVariable placeId: Long,
-    ): ResponseEntity<PlaceWithPlaceReviewsDetailResponse> {
+    ): ResponseEntity<PlaceDetailWithPlaceReviewsResponse> {
         val query = ReadPlaceWithPlaceReviewsUseCase.Query(placeId)
         val results = readPlaceWithPlaceReviewsUseCase.readPlaceWithPlaceReviews(query)
-        return ResponseEntity.ok(PlaceWithPlaceReviewsDetailResponse.from(results))
+        return ResponseEntity.ok(PlaceDetailWithPlaceReviewsResponse.from(results))
     }
 }

--- a/bootstrap/api/src/main/kotlin/kr/wooco/woocobe/api/place/response/PlaceDetailWithPlaceReviewsResponse.kt
+++ b/bootstrap/api/src/main/kotlin/kr/wooco/woocobe/api/place/response/PlaceDetailWithPlaceReviewsResponse.kt
@@ -3,7 +3,7 @@ package kr.wooco.woocobe.api.place.response
 import kr.wooco.woocobe.core.place.application.port.`in`.result.PlaceWithPlaceReviewsResult
 import java.time.LocalDateTime
 
-data class PlaceWithPlaceReviewsDetailResponse(
+data class PlaceDetailWithPlaceReviewsResponse(
     val place: PlaceDetailResponse,
     val placeReviews: List<PlaceReviewDetailResponse>,
 ) {
@@ -25,7 +25,7 @@ data class PlaceWithPlaceReviewsDetailResponse(
 
     companion object {
         fun from(placeWithPlaceReviewsResult: PlaceWithPlaceReviewsResult) =
-            PlaceWithPlaceReviewsDetailResponse(
+            PlaceDetailWithPlaceReviewsResponse(
                 place = PlaceDetailResponse.from(placeWithPlaceReviewsResult.place),
                 placeReviews = placeWithPlaceReviewsResult.placeReviews.map { placeReview ->
                     PlaceReviewDetailResponse(

--- a/bootstrap/api/src/main/kotlin/kr/wooco/woocobe/api/place/response/PlaceWithPlaceReviewsDetailResponse.kt
+++ b/bootstrap/api/src/main/kotlin/kr/wooco/woocobe/api/place/response/PlaceWithPlaceReviewsDetailResponse.kt
@@ -1,0 +1,47 @@
+package kr.wooco.woocobe.api.place.response
+
+import kr.wooco.woocobe.core.place.application.port.`in`.result.PlaceWithPlaceReviewsResult
+import java.time.LocalDateTime
+
+data class PlaceWithPlaceReviewsDetailResponse(
+    val place: PlaceDetailResponse,
+    val placeReviews: List<PlaceReviewDetailResponse>,
+) {
+    data class PlaceReviewDetailResponse(
+        val id: Long,
+        val writer: PlaceReviewWriterResponse,
+        val rating: Double,
+        val contents: String,
+        val createdAt: LocalDateTime,
+        val oneLineReviews: List<String>,
+        val imageUrls: List<String>,
+    )
+
+    data class PlaceReviewWriterResponse(
+        val id: Long,
+        val name: String,
+        val profileUrl: String,
+    )
+
+    companion object {
+        fun from(placeWithPlaceReviewsResult: PlaceWithPlaceReviewsResult) =
+            PlaceWithPlaceReviewsDetailResponse(
+                place = PlaceDetailResponse.from(placeWithPlaceReviewsResult.place),
+                placeReviews = placeWithPlaceReviewsResult.placeReviews.map { placeReview ->
+                    PlaceReviewDetailResponse(
+                        id = placeReview.placeReviewId,
+                        writer = PlaceReviewWriterResponse(
+                            id = placeReview.writer.id,
+                            name = placeReview.writer.name,
+                            profileUrl = placeReview.writer.profileUrl,
+                        ),
+                        rating = placeReview.rating,
+                        contents = placeReview.contents,
+                        createdAt = placeReview.createdAt,
+                        oneLineReviews = placeReview.oneLineReviews,
+                        imageUrls = placeReview.reviewImageUrls,
+                    )
+                },
+            )
+    }
+}

--- a/core/src/main/kotlin/kr/wooco/woocobe/core/place/application/port/in/ReadPlaceWithPlaceReviewsUseCase.kt
+++ b/core/src/main/kotlin/kr/wooco/woocobe/core/place/application/port/in/ReadPlaceWithPlaceReviewsUseCase.kt
@@ -1,0 +1,11 @@
+package kr.wooco.woocobe.core.place.application.port.`in`
+
+import kr.wooco.woocobe.core.place.application.port.`in`.result.PlaceWithPlaceReviewsResult
+
+fun interface ReadPlaceWithPlaceReviewsUseCase {
+    data class Query(
+        val placeId: Long,
+    )
+
+    fun readPlaceWithPlaceReviews(query: Query): PlaceWithPlaceReviewsResult
+}

--- a/core/src/main/kotlin/kr/wooco/woocobe/core/place/application/port/in/result/PlaceWithPlaceReviewsResult.kt
+++ b/core/src/main/kotlin/kr/wooco/woocobe/core/place/application/port/in/result/PlaceWithPlaceReviewsResult.kt
@@ -1,0 +1,61 @@
+package kr.wooco.woocobe.core.place.application.port.`in`.result
+
+import kr.wooco.woocobe.core.place.domain.entity.Place
+import kr.wooco.woocobe.core.placereview.application.service.dto.PlaceOneLineReviewStat
+import kr.wooco.woocobe.core.placereview.domain.entity.PlaceReview
+import kr.wooco.woocobe.core.user.domain.entity.User
+import java.time.LocalDateTime
+
+data class PlaceWithPlaceReviewsResult(
+    val place: PlaceResult,
+    val placeReviews: List<PlaceReviewResult>,
+) {
+    data class PlaceReviewResult(
+        val placeReviewId: Long,
+        val writer: PlaceReviewWriterResult,
+        val contents: String,
+        val rating: Double,
+        val oneLineReviews: List<String>,
+        val reviewImageUrls: List<String>,
+        val createdAt: LocalDateTime,
+    )
+
+    data class PlaceReviewWriterResult(
+        val id: Long,
+        val name: String,
+        val profileUrl: String,
+    )
+
+    companion object {
+        fun of(
+            place: Place,
+            placeOneLineReviewsStats: List<PlaceOneLineReviewStat>,
+            placeReviews: List<PlaceReview>,
+            writers: List<User>,
+        ): PlaceWithPlaceReviewsResult {
+            val writerMap = writers.associateBy { it.id }
+            return PlaceWithPlaceReviewsResult(
+                place = PlaceResult.of(
+                    place,
+                    placeOneLineReviewsStats,
+                ),
+                placeReviews = placeReviews.map { placeReview ->
+                    val writer = requireNotNull(writerMap[placeReview.userId])
+                    PlaceReviewResult(
+                        placeReviewId = placeReview.id,
+                        writer = PlaceReviewWriterResult(
+                            id = writer.id,
+                            name = writer.profile.name,
+                            profileUrl = writer.profile.profileUrl,
+                        ),
+                        contents = placeReview.contents.value,
+                        rating = placeReview.rating.score,
+                        oneLineReviews = placeReview.oneLineReviews.map { it.value },
+                        reviewImageUrls = placeReview.imageUrls,
+                        createdAt = placeReview.writeDateTime,
+                    )
+                },
+            )
+        }
+    }
+}

--- a/core/src/main/kotlin/kr/wooco/woocobe/core/place/application/service/PlaceQueryService.kt
+++ b/core/src/main/kotlin/kr/wooco/woocobe/core/place/application/service/PlaceQueryService.kt
@@ -2,9 +2,12 @@ package kr.wooco.woocobe.core.place.application.service
 
 import kr.wooco.woocobe.core.place.application.port.`in`.ReadAllPlaceUseCase
 import kr.wooco.woocobe.core.place.application.port.`in`.ReadPlaceUseCase
+import kr.wooco.woocobe.core.place.application.port.`in`.ReadPlaceWithPlaceReviewsUseCase
 import kr.wooco.woocobe.core.place.application.port.`in`.result.PlaceResult
+import kr.wooco.woocobe.core.place.application.port.`in`.result.PlaceWithPlaceReviewsResult
 import kr.wooco.woocobe.core.place.application.port.out.PlaceQueryPort
 import kr.wooco.woocobe.core.placereview.application.port.out.PlaceReviewQueryPort
+import kr.wooco.woocobe.core.user.application.port.out.UserQueryPort
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -12,8 +15,10 @@ import org.springframework.transaction.annotation.Transactional
 internal class PlaceQueryService(
     private val placeQueryPort: PlaceQueryPort,
     private val placeReviewQueryPort: PlaceReviewQueryPort,
+    private val userQueryPort: UserQueryPort,
 ) : ReadAllPlaceUseCase,
-    ReadPlaceUseCase {
+    ReadPlaceUseCase,
+    ReadPlaceWithPlaceReviewsUseCase {
     @Transactional(readOnly = true)
     override fun readAllPlace(query: ReadAllPlaceUseCase.Query): List<PlaceResult> {
         val places = placeQueryPort.getAllByPlaceIds(query.placeIds)
@@ -23,8 +28,17 @@ internal class PlaceQueryService(
     @Transactional(readOnly = true)
     override fun readPlace(query: ReadPlaceUseCase.Query): PlaceResult {
         val place = placeQueryPort.getByPlaceId(query.placeId)
-        val placeOneLineReviewStats =
-            placeReviewQueryPort.getAllPlaceOneLineReviewStatsByPlaceId(query.placeId)
+        val placeOneLineReviewStats = placeReviewQueryPort.getAllPlaceOneLineReviewStatsByPlaceId(query.placeId)
         return PlaceResult.of(place, placeOneLineReviewStats)
+    }
+
+    @Transactional(readOnly = true)
+    override fun readPlaceWithPlaceReviews(query: ReadPlaceWithPlaceReviewsUseCase.Query): PlaceWithPlaceReviewsResult {
+        val place = placeQueryPort.getByPlaceId(query.placeId)
+        val placeOneLineReviewStats = placeReviewQueryPort.getAllPlaceOneLineReviewStatsByPlaceId(query.placeId)
+        val placeReviews = placeReviewQueryPort.getTop2ByPlaceId(query.placeId)
+        val writerIds = placeReviews.map { it.userId }.distinct()
+        val writers = userQueryPort.getAllByUserIds(writerIds)
+        return PlaceWithPlaceReviewsResult.of(place, placeOneLineReviewStats, placeReviews, writers)
     }
 }

--- a/core/src/main/kotlin/kr/wooco/woocobe/core/placereview/application/port/out/PlaceReviewQueryPort.kt
+++ b/core/src/main/kotlin/kr/wooco/woocobe/core/placereview/application/port/out/PlaceReviewQueryPort.kt
@@ -23,4 +23,7 @@ interface PlaceReviewQueryPort {
     fun getAllPlaceOneLineReviewStatsByPlaceId(placeId: Long): List<PlaceOneLineReviewStat>
 
     fun countByUserId(userId: Long): Long
+
+    // 더 괜찮은 네이밍으로 수정 가능
+    fun getTop2ByPlaceId(placeId: Long): List<PlaceReview>
 }

--- a/infrastructure/mysql/src/main/kotlin/kr/wooco/woocobe/mysql/placereview/PlaceReviewPersistenceAdapter.kt
+++ b/infrastructure/mysql/src/main/kotlin/kr/wooco/woocobe/mysql/placereview/PlaceReviewPersistenceAdapter.kt
@@ -91,4 +91,9 @@ internal class PlaceReviewPersistenceAdapter(
         placeOneLineReviewJpaRepository.findPlaceOneLineReviewStatsByPlaceId(placeId, PageRequest.of(0, 5))
 
     override fun countByUserId(userId: Long): Long = placeReviewJpaRepository.countByUserId(userId)
+
+    override fun getTop2ByPlaceId(placeId: Long): List<PlaceReview> {
+        val placeReviewJpaEntities = placeReviewJpaRepository.findTop2ByPlaceId(placeId, PageRequest.of(0, 2))
+        return convertPlaceReviews(placeReviewJpaEntities)
+    }
 }

--- a/infrastructure/mysql/src/main/kotlin/kr/wooco/woocobe/mysql/placereview/repository/PlaceReviewJpaRepository.kt
+++ b/infrastructure/mysql/src/main/kotlin/kr/wooco/woocobe/mysql/placereview/repository/PlaceReviewJpaRepository.kt
@@ -2,6 +2,7 @@ package kr.wooco.woocobe.mysql.placereview.repository
 
 import kr.wooco.woocobe.core.placereview.application.service.dto.PlaceReviewStats
 import kr.wooco.woocobe.mysql.placereview.entity.PlaceReviewJpaEntity
+import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 
@@ -55,4 +56,17 @@ interface PlaceReviewJpaRepository : JpaRepository<PlaceReviewJpaEntity, Long> {
     ): Boolean
 
     fun countByUserId(userId: Long): Long
+
+    @Query(
+        """
+            SELECT pr
+            FROM PlaceReviewJpaEntity pr
+            WHERE pr.placeId = :placeId
+              AND pr.status = 'ACTIVE'
+        """,
+    )
+    fun findTop2ByPlaceId(
+        placeId: Long,
+        pageable: Pageable,
+    ): List<PlaceReviewJpaEntity>
 }


### PR DESCRIPTION
## 📝 개요

<!-- 이 PR의 목적과 관련된 정보를 간략히 설명합니다. -->

- 장소 상세 정보와 장소 리뷰 목록(상위 2개)을 동시에 조회할 수 있는 API를 추가했습니다.


## ✨ 변경 사항

<!-- 코드나 기능의 주요 변경 사항을 설명 -->

-  `GET /places/{placeId}/aggregation` API 추가
-  `PlaceQueryService`에 readPlaceWithPlaceReviews 구현
   - `ReadPlaceWithPlaceReviewsUseCase` 및 Query/Result 정의
-  `PlaceReviewJpaRepository`에 Top2 리뷰 조회 쿼리 추가

## 🔗 관련 이슈

<!-- 이 PR과 관련된 이슈 번호를 연결 (없으면 생략) -->

- closed #241

## ℹ️ 참고 사항
- API 테스트 완료 했습니다.
- `getTop2ByPlaceId` 보다 괜찮은 네이밍 있으면 지적 부탁드립니다. 감사합니다.