### PR TITLE
build: 빌드 이미지 크기 개선 및 배포 파이프라인 수정

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -2,9 +2,8 @@ name: Deploy PROD
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - main
+  release:
+    types: [ published ]
 
 jobs:
   docker-build-and-push:
@@ -55,25 +54,36 @@ jobs:
           file: ./Dockerfile-api
           push: true
           platforms: linux/amd64
-          tags: ${{ secrets.DOCKER_HUB_REPOSITORY }}:${{ secrets.IMAGE_TAG }}
+          tags: ${{ secrets.DOCKER_HUB_REPOSITORY }}:${{ github.event.release.tag_name }}
 
-  docker-pull-and-run:
-    runs-on: [ self-hosted, Linux, X64, prod ]
-    environment: prod
+  # argocd image updater 도입시 제거될 예정
+  update-deployment:
+    runs-on: ubuntu-latest
     needs: docker-build-and-push
     if: success()
 
     steps:
-      - name: 배포 이미지 가져오기
-        run: |
-          sudo docker login --username ${{ secrets.DOCKER_HUB_USERNAME }} --password ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
-          sudo docker pull ${{ secrets.DOCKER_HUB_REPOSITORY }}:${{ secrets.IMAGE_TAG }}
+      - name: 리포지토리 체크아웃
+        uses: actions/checkout@v3
+        with:
+          repository: ${{ vars.ORG_GITOPS_REPOSITORY }} # team-joytas/wooco-gitops
+          token: ${{ secrets.ORG_GITOPS_PAT }}
 
-      - name: blue green 배포 스크립트 실행
-        run: |
-          sudo chmod +x deploy.sh
-          sudo ./deploy.sh
+      - name: 이미지 버전 변경 # kustomize cli 대신 yq 사용
+        uses: mikefarah/yq@v4.44.3
+        with:
+          cmd: >
+            yq -i
+            '.spec.template.spec.containers[0].image =
+            "${{ secrets.DOCKER_HUB_REPOSITORY }}:${{ github.event.release.tag_name }}"'
+            ./${{ vars.ORG_GITOPS_PROD_DEPLOYMENT_PATH }}
 
-      - name: 사용하지 않는 도커 이미지 정리
+      # https://github.com/simonw/simonw/issues/11
+      - name: 커밋 & 푸시
         run: |
-          sudo docker image prune --all --force
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add .
+          git commit -m "release: Deploy ${{ github.event.release.tag_name }} wooco spring app"
+          git remote set-url origin https://${{ secrets.ORG_GITOPS_PAT }}@github.com/${{ vars.ORG_GITOPS_REPOSITORY }}
+          git push --set-upstream origin HEAD

--- a/Dockerfile-api
+++ b/Dockerfile-api
@@ -1,8 +1,64 @@
-FROM amazoncorretto:21-alpine-jdk
+# Distroless 기반 이미지로 마이그레이션 검토
+#============================ STAGE: JDEPS 의존성 분석 ============================
+FROM amazoncorretto:21-alpine3.21 AS deps
+
+COPY ./build/libs/api-*.jar /app/app.jar
+
+RUN mkdir /app/unpacked \
+    && cd /app/unpacked \
+    && unzip ../app.jar \
+    && cd .. \
+    && $JAVA_HOME/bin/jdeps \
+    --ignore-missing-deps \
+    --print-module-deps \
+    --recursive -q \
+    --multi-release 21 \
+    --class-path="./unpacked/BOOT-INF/lib/*" \
+    --module-path="./unpacked/BOOT-INF/lib/*" \
+    ./app.jar > /deps.info
+
+
+#============================ STAGE: JRE 생성 ============================
+FROM amazoncorretto:21-alpine3.21 AS jre-builder
+
+RUN apk add --no-cache binutils
+
+COPY --from=deps /deps.info /deps.info
+
+# crypto 모듈: SSLHandshakeException 오류 해결용
+# jcmd 모듈: jvm 디버깅용
+ENV EXTRA_MODULES="jdk.crypto.ec,jdk.jcmd"
+RUN $JAVA_HOME/bin/jlink \
+    --verbose \
+    --add-modules "$(cat /deps.info),${EXTRA_MODULES}" \
+    --strip-debug \
+    --no-man-pages \
+    --no-header-files \
+    --compress=2 \
+    --output /opt/jre-min
+
+
+#============================ STAGE:3 alpine3.21 기반 런타임 이미지 ============================
+FROM alpine:3.21
+
+RUN addgroup -g 1000 appuser \
+    && adduser -D -u 1000 -G appuser -H -s /sbin/nologin appuser
+
+COPY --from=jre-builder /opt/jre-min /opt/jre
 
 WORKDIR /app
-COPY ./build/libs/api-*.jar /app/wooco-be.jar
+COPY --chown=appuser:appuser ./build/libs/api-*.jar /app/app.jar
 
+USER appuser:appuser
+
+ENV JAVA_HOME=/opt/jre
+ENV PATH="$JAVA_HOME/bin:${PATH}"
 ENV TZ=Asia/Seoul
+ENV JAVA_TOOL_OPTIONS="\
+  -Duser.timezone=Asia/Seoul \
+  -Djava.io.tmpdir=/tmp \
+  -Djava.net.preferIPv4Stack=true"
 
-CMD ["java", "-jar", "-Djava.net.preferIPv4Stack=true", "wooco-be.jar"]
+COPY --chown=appuser:appuser --chmod=0755 ./scripts/run.sh /app/run.sh
+
+ENTRYPOINT ["/app/run.sh"]

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+# shellcheck disable=SC2086
+exec java ${JAVA_OPTS:-} -jar /app/app.jar "$@"
+


### PR DESCRIPTION
## 📝 개요

<!-- 이 PR의 목적과 관련된 정보를 간략히 설명합니다. -->

빌드 이미지 크기 압축과 non-root 설정 및 CI/CD 파이프라인을 gitops와 결합시켰습니다

## ✨ 변경 사항

<!-- 코드나 기능의 주요 변경 사항을 설명 -->

- ✨빌드 이미지 개선 (기존 약 500MB -> 개선 190MB)
- ✨non-root 로 애플리케이션을 실행하도록 수정
- ✨CD 파이프라인에 gitops 리포지토리에 직접 커밋하도록 수정

## 🔗 관련 이슈

<!-- 이 PR과 관련된 이슈 번호를 연결 (없으면 생략) -->

- closed #244 

## ℹ️ 참고 사항

<!-- 리뷰어가 알 필요가 있는 추가 정보나 문서, 참고 링크를 포함 (없으면 생략) -->

jlink 와 jdeps 사용해서 빌드 이미지 압축했습니다! (debian12 기반과 alpine3.21 기반 모두 대략 50~60% 정도의 압축률)

<img width="782" height="86" alt="스크린샷 2025-09-15 오후 3 57 28" src="https://github.com/user-attachments/assets/3b738e8f-8443-496d-a5b8-177352cd37cd" /><br/>
- 데비안 베이스 이미지 압축 결과 (558MB -> 284MB)
- 알파인 베이스 이미지 압축 결과 (477MB -> 196MB)

참고)
jdeps 로 필요한 모듈 분석해서 jre에 넣고 테스트 해봤는데 `jdk.crypto.ec` 모듈이 없어 `SSLHandshakeException` 오류가 뜨고있어서 `EXTRA_MODULES`로 넣어둔 상태입니다. 또한, `jcmd` 는 jvm 디버깅용도로 넣어놨습니다!

(구글링해보니까 `jdk.crypto.ec` 모듈은 deprecated 되었다는데 라이브러리 어딘가에서 아직 사용중인 것 같습니다.. 그래서 누락된것 같네유)

운영중 모듈 누락으로 인해 오류 발생시 jdeps 의존성 분석 스테이지 제거하고 `ALL-MODULE-PATH`으로 수정할 예정입니닷!



