### PR TITLE
chore: Docker MySQL 8.4, Redis 7.2 LTS 버전 업데이트

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   mysql:
-    image: mysql:8.1.0
+    image: mysql:8.4
     container_name: mysql8-local
     restart: always
     ports:
@@ -15,7 +15,7 @@ services:
       - ./init.sql:/docker-entrypoint-initdb.d/init.sql
 
   redis:
-    image: redis:7.2.4-alpine
+    image: redis:7.2-alpine
     container_name: redis7-local
     command: redis-server --port 6379
     restart: always


### PR DESCRIPTION
## Summary
- MySQL 이미지 버전을 `8.1.0` → `8.4` (LTS)로 업데이트
- Redis 이미지 태그를 `7.2.4-alpine` → `7.2-alpine` (7.2 LTS 최신 패치 자동 적용)으로 변경

## Changes
- `docker/docker-compose.yml`: MySQL, Redis 이미지 태그 변경
